### PR TITLE
Telegram Document Download Error Fix

### DIFF
--- a/bot/helper/mirror_utils/download_utils/telegram_downloader.py
+++ b/bot/helper/mirror_utils/download_utils/telegram_downloader.py
@@ -87,7 +87,7 @@ class TelegramDownloadHelper:
     def add_download(self, message, path, filename):
         _dmsg = app.get_messages(message.chat.id, reply_to_message_ids=message.message_id)
         media = None
-        media_array = [_dmsg, _dmsg.video, _dmsg.audio]
+        media_array = [_dmsg.document, _dmsg.video, _dmsg.audio]
         for i in media_array:
             if i is not None:
                 media = i


### PR DESCRIPTION
Error Fix for :

AttributeError: 'Message' object has no attribute 'file_id'