### PR TITLE
Fix asyncio Task exception was never retrieved

### DIFF
--- a/bot/helper/mirror_utils/download_utils/telegram_downloader.py
+++ b/bot/helper/mirror_utils/download_utils/telegram_downloader.py
@@ -3,7 +3,7 @@ from logging import getLogger, WARNING
 from time import time
 from threading import RLock, Lock
 from pyrogram import Client, enums
-from asyncio import run
+from asyncio import get_event_loop, gather
 
 from bot import LOGGER, download_dict, download_dict_lock, STOP_DUPLICATE, STORAGE_THRESHOLD, \
                  TELEGRAM_API, TELEGRAM_HASH, BOT_TOKEN
@@ -133,6 +133,7 @@ class TelegramDownloadHelper:
         self.__onDownloadError('Cancelled by user!')
 
     def async_starter(self, message, path, filename):
-        run(self.__add_download(message, path, filename))
+        loop = get_event_loop()
+        loop.run_until_complete(gather(self.__add_download(message, path, filename)))
         if self.__path is not None:
             self.__listener.onDownloadComplete()


### PR DESCRIPTION
 2022-06-01 19:37:14,799 - asyncio - ERROR - Task exception was never retrieved
 future: <Task finished name='Task-3021' coro=<Syncer.worker() done, defined at /usr/local/lib/python3.8/dist-packages/pyrogram/syncer.py:68> exception=RuntimeError("Task <Task pending name='Task-3023' coro=<Event.wait() running at /usr/lib/python3.8/asyncio/locks.py:309> cb=[_release_waiter(<Future pendi...008474b80>()]>)() at /usr/lib/python3.8/asyncio/tasks.py:429]> got Future <Future pending> attached to a different loop")>
 Traceback (most recent call last):
   File "/usr/local/lib/python3.8/dist-packages/pyrogram/syncer.py", line 72, in worker
     await asyncio.wait_for(cls.event.wait(), cls.INTERVAL)
   File "/usr/lib/python3.8/asyncio/tasks.py", line 494, in wait_for
     return fut.result()
   File "/usr/lib/python3.8/asyncio/locks.py", line 309, in wait
     await fut
 RuntimeError: Task <Task pending name='Task-3023' coro=<Event.wait() running at /usr/lib/python3.8/asyncio/locks.py:309> cb=[_release_waiter(<Future pendi...008474b80>()]>)() at /usr/lib/python3.8/asyncio/tasks.py:429]> got Future <Future pending> attached to a different loop
 2022-06-01 19:37:57,756 - bot.helper.mirror_utils.upload_utils.pyrogramEngine - INFO - Leech Completed: