### PR TITLE
Telegram trims file names larger than 60 characters

### DIFF
--- a/bot/helper/mirror_utils/download_utils/telegram_downloader.py
+++ b/bot/helper/mirror_utils/download_utils/telegram_downloader.py
@@ -89,6 +89,9 @@ class TelegramDownloadHelper:
                 download = media.file_unique_id not in GLOBAL_GID
             if filename == "":
                 name = media.file_name
+                if "_" in name:
+                    name = _dmsg.caption.split("\n")[0]
+                    path = path + name
             else:
                 name = filename
                 path = path + name


### PR DESCRIPTION
Telegram trims file names larger than 60 characters, but uploading to google drive does not have the limit.

so, in my opinion, we should get real file name from the caption instead of using the trimmed filename