### PR TITLE
fixed exposed ports to open internet and added volume mount in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   app:
     build: .
     command: bash start.sh
+    volumes:
+      - $HOME/mirror-leech-telegram-bot/config.env:/usr/src/app/config.env
     restart: on-failure
     ports:
-      - "80:80"
+      - "127.0.0.1:80:80"


### PR DESCRIPTION
Mentioning only ports will bind the localhost to 0.0.0.0 and hence it will be exposed to the open internet. Specifying the localhost will ensure that it is not reachable from outside.