### PR TITLE
Make bot PMs the User with file

### DIFF
--- a/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
+++ b/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
@@ -82,6 +82,7 @@ class TgUploader:
         notMedia = False
         thumb = self.__thumb
         self.__is_corrupted = False
+        leechchat = self.__listener.message.from_user.id
         try:
             is_video, is_audio = get_media_streams(up_path)
             if not self.__as_doc:
@@ -104,8 +105,7 @@ class TgUploader:
                         new_path = ospath.join(dirpath, file_)
                         osrename(up_path, new_path)
                         up_path = new_path
-                    self.__sent_msg = self.__sent_msg.reply_video(video=up_path,
-                                                                  quote=True,
+                    self.__sent_msg = app.send_video(chat_id=leechchat, video=up_path,
                                                                   caption=cap_mono,
                                                                   duration=duration,
                                                                   width=width,
@@ -116,8 +116,7 @@ class TgUploader:
                                                                   progress=self.__upload_progress)
                 elif is_audio:
                     duration , artist, title = get_media_info(up_path)
-                    self.__sent_msg = self.__sent_msg.reply_audio(audio=up_path,
-                                                                  quote=True,
+                    self.__sent_msg = app.send_audio(chat_id=leechchat, audio=up_path,
                                                                   caption=cap_mono,
                                                                   duration=duration,
                                                                   performer=artist,
@@ -126,8 +125,7 @@ class TgUploader:
                                                                   disable_notification=True,
                                                                   progress=self.__upload_progress)
                 elif file_.upper().endswith(IMAGE_SUFFIXES):
-                    self.__sent_msg = self.__sent_msg.reply_photo(photo=up_path,
-                                                                  quote=True,
+                    self.__sent_msg = app.send_photo(chat_id=leechchat, photo=up_path,
                                                                   caption=cap_mono,
                                                                   disable_notification=True,
                                                                   progress=self.__upload_progress)
@@ -140,8 +138,7 @@ class TgUploader:
                         if self.__thumb is None and thumb is not None and ospath.lexists(thumb):
                             osremove(thumb)
                         return
-                self.__sent_msg = self.__sent_msg.reply_document(document=up_path,
-                                                                 quote=True,
+                self.__sent_msg = app.send_document(chat_id=leechchat, document=up_path,
                                                                  thumb=thumb,
                                                                  caption=cap_mono,
                                                                  disable_notification=True,


### PR DESCRIPTION
Make bot PMs the User with file instead of posting it to group. 

This will help avoid group bans and group confusion.