### PR TITLE
Add a stream index link button only for video file types

### DIFF
--- a/bot/helper/listener.py
+++ b/bot/helper/listener.py
@@ -5,6 +5,7 @@ from os import walk, path as ospath
 from html import escape
 from aioshutil import move
 from asyncio import create_subprocess_exec, sleep, Event
+import base64
 
 from bot import Interval, aria2, DOWNLOAD_DIR, download_dict, download_dict_lock, LOGGER, DATABASE_URL, MAX_SPLIT_SIZE, config_dict, status_reply_dict_lock, user_data, non_queued_up, non_queued_dl, queued_up, queued_dl, queue_dict_lock
 from bot.helper.ext_utils.bot_utils import sync_to_async
@@ -303,6 +304,19 @@ class MirrorLeechListener:
                 if typ == "Folder":
                     share_url += '/'
                     buttons.ubutton("⚡ Index Link", share_url)
+                elif "video" in typ:
+                    result_get_0 = INDEX_URL.split("/")[3]
+                    resultpath = '/' + result_get_0 + '/' + escape(name)
+                    encoded_string = base64.b64encode(resultpath.encode("utf-8"))
+                    result_rmv_b = encoded_string.decode('utf-8')
+                    result_rmv_b = result_rmv_b.replace('/', '_')
+                    result_rmv_b = result_rmv_b.replace('+', '-')
+                    if result_rmv_b.startswith('b'):
+                        result_rmv_b = result_rmv_b[1:]
+                    INDEX_URLVIDEO = INDEX_URL.replace(result_get_0, "0:video/")
+                    share_urlvideo = INDEX_URLVIDEO + result_rmv_b
+                    buttons.ubutton("⚡ Index Link", share_url)
+                    buttons.ubutton("🎬 Stream Link", share_urlvideo)
                 else:
                     buttons.ubutton("⚡ Index Link", share_url)
                     if config_dict['VIEW_LINK']:

--- a/bot/helper/listener.py
+++ b/bot/helper/listener.py
@@ -307,12 +307,7 @@ class MirrorLeechListener:
                 elif "video" in typ:
                     result_get_0 = INDEX_URL.split("/")[3]
                     resultpath = '/' + result_get_0 + '/' + escape(name)
-                    encoded_string = base64.b64encode(resultpath.encode("utf-8"))
-                    result_rmv_b = encoded_string.decode('utf-8')
-                    result_rmv_b = result_rmv_b.replace('/', '_')
-                    result_rmv_b = result_rmv_b.replace('+', '-')
-                    if result_rmv_b.startswith('b'):
-                        result_rmv_b = result_rmv_b[1:]
+                    result_rmv_b = base64.urlsafe_b64encode(resultpath.encode("utf-8")).decode('utf-8').rstrip('=')
                     INDEX_URLVIDEO = INDEX_URL.replace(result_get_0, "0:video/")
                     share_urlvideo = INDEX_URLVIDEO + result_rmv_b
                     buttons.ubutton("⚡ Index Link", share_url)

--- a/bot/helper/mirror_utils/upload_utils/gdriveTools.py
+++ b/bot/helper/mirror_utils/upload_utils/gdriveTools.py
@@ -385,13 +385,8 @@ class GoogleDriveHelper:
                     url = f'{INDEX_URL}/{url_path}/'
                     if "video" in mime_type:
                         result_get_0 = INDEX_URL.split("/")[3]
-                        resultpath = '/' + result_get_0 + '/' + meta.get("name")
-                        encoded_string = base64.b64encode(resultpath.encode("utf-8"))
-                        result_rmv_b = encoded_string.decode('utf-8')
-                        result_rmv_b = result_rmv_b.replace('/', '_')
-                        result_rmv_b = result_rmv_b.replace('+', '-')
-                        if result_rmv_b.startswith('b'):
-                            result_rmv_b = result_rmv_b[1:]
+                        resultpath = '/' + result_get_0 + '/' + file.get("name")
+                        result_rmv_b = base64.urlsafe_b64encode(resultpath.encode("utf-8")).decode('utf-8').rstrip('=')
                         INDEX_URLVIDEO = INDEX_URL.replace(result_get_0, "0:video/")
                         share_urlvideo = INDEX_URLVIDEO + result_rmv_b
                         buttons.ubutton("⚡ Index Link", url)
@@ -416,13 +411,8 @@ class GoogleDriveHelper:
                         buttons.ubutton("🌐 View Link", urlv)
                     elif "video" in mime_type:
                         result_get_0 = INDEX_URL.split("/")[3]
-                        resultpath = '/' + result_get_0 + '/' + meta.get("name")
-                        encoded_string = base64.b64encode(resultpath.encode("utf-8"))
-                        result_rmv_b = encoded_string.decode('utf-8')
-                        result_rmv_b = result_rmv_b.replace('/', '_')
-                        result_rmv_b = result_rmv_b.replace('+', '-')
-                        if result_rmv_b.startswith('b'):
-                            result_rmv_b = result_rmv_b[1:]
+                        resultpath = '/' + result_get_0 + '/' + file.get("name")
+                        result_rmv_b = base64.urlsafe_b64encode(resultpath.encode("utf-8")).decode('utf-8').rstrip('=')
                         INDEX_URLVIDEO = INDEX_URL.replace(result_get_0, "0:video/")
                         share_urlvideo = INDEX_URLVIDEO + result_rmv_b
                         buttons.ubutton("⚡ Index Link", url)

--- a/bot/helper/mirror_utils/upload_utils/gdriveTools.py
+++ b/bot/helper/mirror_utils/upload_utils/gdriveTools.py
@@ -383,6 +383,19 @@ class GoogleDriveHelper:
                     url_path = rquote(f'{meta.get("name")}', safe='')
                     url = f'{INDEX_URL}/{url_path}/'
                     buttons.ubutton("⚡ Index Link", url)
+                elif "video" in typ:
+                    result_get_0 = INDEX_URL.split("/")[3]
+                    resultpath = '/' + result_get_0 + '/' + escape(name)
+                    encoded_string = base64.b64encode(resultpath.encode("utf-8"))
+                    result_rmv_b = encoded_string.decode('utf-8')
+                    result_rmv_b = result_rmv_b.replace('/', '_')
+                    result_rmv_b = result_rmv_b.replace('+', '-')
+                    if result_rmv_b.startswith('b'):
+                        result_rmv_b = result_rmv_b[1:]
+                    INDEX_URLVIDEO = INDEX_URL.replace(result_get_0, "0:video/")
+                    share_urlvideo = INDEX_URLVIDEO + result_rmv_b
+                    buttons.ubutton("⚡ Index Link", share_url)
+                    buttons.ubutton("🎬 Stream Link", share_urlvideo)
             else:
                 file = self.__copyFile(meta.get('id'), config_dict['GDRIVE_ID'])
                 msg += f'<b>Name: </b><code>{file.get("name")}</code>'

--- a/bot/helper/mirror_utils/upload_utils/gdriveTools.py
+++ b/bot/helper/mirror_utils/upload_utils/gdriveTools.py
@@ -12,6 +12,7 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception_type, RetryError
+import base64
 
 from bot.helper.telegram_helper.button_build import ButtonMaker
 from bot import config_dict, DRIVES_NAMES, DRIVES_IDS, INDEX_URLS, GLOBAL_EXTENSION_FILTER
@@ -382,20 +383,21 @@ class GoogleDriveHelper:
                 if INDEX_URL := config_dict['INDEX_URL']:
                     url_path = rquote(f'{meta.get("name")}', safe='')
                     url = f'{INDEX_URL}/{url_path}/'
-                    buttons.ubutton("⚡ Index Link", url)
-                elif "video" in typ:
-                    result_get_0 = INDEX_URL.split("/")[3]
-                    resultpath = '/' + result_get_0 + '/' + escape(name)
-                    encoded_string = base64.b64encode(resultpath.encode("utf-8"))
-                    result_rmv_b = encoded_string.decode('utf-8')
-                    result_rmv_b = result_rmv_b.replace('/', '_')
-                    result_rmv_b = result_rmv_b.replace('+', '-')
-                    if result_rmv_b.startswith('b'):
-                        result_rmv_b = result_rmv_b[1:]
-                    INDEX_URLVIDEO = INDEX_URL.replace(result_get_0, "0:video/")
-                    share_urlvideo = INDEX_URLVIDEO + result_rmv_b
-                    buttons.ubutton("⚡ Index Link", share_url)
-                    buttons.ubutton("🎬 Stream Link", share_urlvideo)
+                    if "video" in mime_type:
+                        result_get_0 = INDEX_URL.split("/")[3]
+                        resultpath = '/' + result_get_0 + '/' + meta.get("name")
+                        encoded_string = base64.b64encode(resultpath.encode("utf-8"))
+                        result_rmv_b = encoded_string.decode('utf-8')
+                        result_rmv_b = result_rmv_b.replace('/', '_')
+                        result_rmv_b = result_rmv_b.replace('+', '-')
+                        if result_rmv_b.startswith('b'):
+                            result_rmv_b = result_rmv_b[1:]
+                        INDEX_URLVIDEO = INDEX_URL.replace(result_get_0, "0:video/")
+                        share_urlvideo = INDEX_URLVIDEO + result_rmv_b
+                        buttons.ubutton("⚡ Index Link", url)
+                        buttons.ubutton("🎬 Stream Link", share_urlvideo)
+                    else:
+                        buttons.ubutton("⚡ Index Link", url)
             else:
                 file = self.__copyFile(meta.get('id'), config_dict['GDRIVE_ID'])
                 msg += f'<b>Name: </b><code>{file.get("name")}</code>'
@@ -409,10 +411,24 @@ class GoogleDriveHelper:
                 if INDEX_URL := config_dict['INDEX_URL']:
                     url_path = rquote(f'{file.get("name")}', safe='')
                     url = f'{INDEX_URL}/{url_path}'
-                    buttons.ubutton("⚡ Index Link", url)
                     if config_dict['VIEW_LINK']:
                         urlv = f'{INDEX_URL}/{url_path}?a=view'
                         buttons.ubutton("🌐 View Link", urlv)
+                    elif "video" in mime_type:
+                        result_get_0 = INDEX_URL.split("/")[3]
+                        resultpath = '/' + result_get_0 + '/' + meta.get("name")
+                        encoded_string = base64.b64encode(resultpath.encode("utf-8"))
+                        result_rmv_b = encoded_string.decode('utf-8')
+                        result_rmv_b = result_rmv_b.replace('/', '_')
+                        result_rmv_b = result_rmv_b.replace('+', '-')
+                        if result_rmv_b.startswith('b'):
+                            result_rmv_b = result_rmv_b[1:]
+                        INDEX_URLVIDEO = INDEX_URL.replace(result_get_0, "0:video/")
+                        share_urlvideo = INDEX_URLVIDEO + result_rmv_b
+                        buttons.ubutton("⚡ Index Link", url)
+                        buttons.ubutton("🎬 Stream Link", share_urlvideo)
+                    else:
+                        buttons.ubutton("⚡ Index Link", url)
         except Exception as err:
             if isinstance(err, RetryError):
                 LOGGER.info(f"Total Attempts: {err.last_attempt.attempt_number}")


### PR DESCRIPTION
 _Added a stream link button that goes to the index url, a stream link button will appear if the file type is video, only applies to mirror, ytdl, clone commands_

### **Screenshot Example**
![image](https://user-images.githubusercontent.com/118915239/220984535-a2a78d2b-61c2-4ba8-aa25-7e41cc1818be.png)
