### PR TITLE
chore: rclone serve process logs to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ downloads
 bot.session*
 terabox.txt
 rclone.conf
+# qBittorrent runtime files
+qBittorrent/config/rss/storage.lock
+qBittorrent/config/qBittorrent-data.conf
+qBittorrent/config/lockfile

--- a/bot/helper/mirror_utils/rclone_utils/serve.py
+++ b/bot/helper/mirror_utils/rclone_utils/serve.py
@@ -1,4 +1,5 @@
 from asyncio import create_subprocess_exec
+import os
 from aiofiles.os import path as aiopath
 from aiofiles import open as aiopen
 from configparser import ConfigParser
@@ -35,10 +36,15 @@ async def rclone_serve_booter():
             RcloneServe.clear()
         except:
             pass
+    try:
+        os.remove("rlogserve.txt")
+    except OSError:
+        pass
+
     cmd = ["rclone", "serve", "http", "--config", "rclone.conf", "--no-modtime",
            "combine:", "--addr", f":{config_dict['RCLONE_SERVE_PORT']}",
            "--vfs-cache-mode", "full", "--vfs-cache-max-age", "1m0s",
-           "--buffer-size", "64M"]
+           "--buffer-size", "64M", "--log-file", "rlogserve.txt"]
     if (user := config_dict['RCLONE_SERVE_USER']) and (pswd := config_dict['RCLONE_SERVE_PASS']):
         cmd.extend(("--user", user, "--pass", pswd))
     rcs = await create_subprocess_exec(*cmd)


### PR DESCRIPTION
Hello, there has been some times that the rclone index has been down, i needed to see what did went wrong and i wasn't able to get any idea of that via `/log` or `/shell cat rlog.txt` so i thought it might help.

However, that didn't happen anymore since a few changes i made to the remote.
Anyway, it might help.