### PR TITLE
Fix buzzheavier directlink

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -255,9 +255,11 @@ def buzzheavier(url):
 
         if not d_url:
             raise DirectDownloadLinkException("ERROR: Failed to fetch direct link.")
-
-        parsed_url = urlparse(url)
-        return f"{parsed_url.scheme}://{parsed_url.netloc}{d_url}"
+        if d_url.startswith("http://") or d_url.startswith("https://"):
+            return d_url
+        else:
+            parsed_url = urlparse(url)
+            return f"{parsed_url.scheme}://{parsed_url.netloc}{d_url}"
     except Exception as e:
         raise DirectDownloadLinkException(f"ERROR: {str(e)}") from e
     finally:


### PR DESCRIPTION
just mirroring file from buzzheavier and got the wrong direct link.

2025-05-08 17:09:42,393 - bot - INFO - Bot Started!
2025-05-08 17:09:45,263 - bot - INFO - https://buzzheavier.com/3uyqryaemnly
2025-05-08 17:09:45,899 - bot - INFO - Generated link: https://buzzheavier.comhttps://flashbang.sh/dl/J3Q4fP3p4OIpvdGYYOdV8w84Qf0NJBJS_zh06qApUnKNdR0OzIRsuU7M-pb0sE4pS9oINf2z1i6yO_SaZEngoizn1v2WUW1DOgeMyMo6EW29bN8-QWsKP8mCKnM5E9ISVnfSVhNx3cnorCYVeX2RGTbD?v=1746724016-6OLEaKDED5QGgwKRUxCtBh59Z3bMuwTBdj8CCcQIgSA%3D
2025-05-08 17:09:45,906 - bot - INFO - Aria2c Download Error: Aria2rpcException: unexpected result: {'id': 6, 'jsonrpc': '2.0', 'error': {'code': 1, 'message': 'No URI to download.'}}


