### PR TITLE
Add environment variable support for config values

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -1,225 +1,229 @@
 from importlib import import_module
 from ast import literal_eval
+from typing import Any, Dict, List, Optional
 import os
 
 
 class Config:
-    AS_DOCUMENT = False
-    AUTHORIZED_CHATS = ""
-    BASE_URL = ""
-    BASE_URL_PORT = 80
-    BOT_TOKEN = ""
-    CMD_SUFFIX = ""
-    DATABASE_URL = ""
-    DEFAULT_UPLOAD = "rc"
-    EQUAL_SPLITS = False
-    EXCLUDED_EXTENSIONS = ""
-    FFMPEG_CMDS = {}
-    FILELION_API = ""
-    GDRIVE_ID = ""
-    INCOMPLETE_TASK_NOTIFIER = False
-    INDEX_URL = ""
-    IS_TEAM_DRIVE = False
-    JD_EMAIL = ""
-    JD_PASS = ""
-    LEECH_DUMP_CHAT = ""
-    LEECH_FILENAME_PREFIX = ""
-    LEECH_SPLIT_SIZE = 2097152000
-    MEDIA_GROUP = False
-    HYBRID_LEECH = False
-    HYDRA_IP = ""
-    HYDRA_API_KEY = ""
-    NAME_SUBSTITUTE = ""
-    OWNER_ID = 0
-    QUEUE_ALL = 0
-    QUEUE_DOWNLOAD = 0
-    QUEUE_UPLOAD = 0
-    RCLONE_FLAGS = ""
-    RCLONE_PATH = ""
-    RCLONE_SERVE_URL = ""
-    RCLONE_SERVE_USER = ""
-    RCLONE_SERVE_PASS = ""
-    RCLONE_SERVE_PORT = 8080
-    RSS_CHAT = ""
-    RSS_DELAY = 600
-    RSS_SIZE_LIMIT = 0
-    SEARCH_API_LINK = ""
-    SEARCH_LIMIT = 0
-    SEARCH_PLUGINS = []
-    STATUS_LIMIT = 4
-    STATUS_UPDATE_INTERVAL = 15
-    STOP_DUPLICATE = False
-    STREAMWISH_API = ""
-    SUDO_USERS = ""
-    TELEGRAM_API = 0
-    TELEGRAM_HASH = ""
-    TG_PROXY = {}
-    THUMBNAIL_LAYOUT = ""
-    TORRENT_TIMEOUT = 0
-    UPLOAD_PATHS = {}
-    UPSTREAM_REPO = ""
-    UPSTREAM_BRANCH = "master"
-    USENET_SERVERS = []
-    USER_SESSION_STRING = ""
-    USER_TRANSMISSION = False
-    USE_SERVICE_ACCOUNTS = False
-    WEB_PINCODE = False
-    YT_DLP_OPTIONS = {}
+    AS_DOCUMENT: bool = False
+    AUTHORIZED_CHATS: str = ""
+    BASE_URL: str = ""
+    BASE_URL_PORT: int = 80
+    BOT_TOKEN: str = ""
+    CMD_SUFFIX: str = ""
+    DATABASE_URL: str = ""
+    DEFAULT_UPLOAD: str = "rc"
+    EQUAL_SPLITS: bool = False
+    EXCLUDED_EXTENSIONS: str = ""
+    FFMPEG_CMDS: Dict[str, Any] = {}
+    FILELION_API: str = ""
+    GDRIVE_ID: str = ""
+    INCOMPLETE_TASK_NOTIFIER: bool = False
+    INDEX_URL: str = ""
+    IS_TEAM_DRIVE: bool = False
+    JD_EMAIL: str = ""
+    JD_PASS: str = ""
+    LEECH_DUMP_CHAT: str = ""
+    LEECH_FILENAME_PREFIX: str = ""
+    LEECH_SPLIT_SIZE: int = 2097152000
+    MEDIA_GROUP: bool = False
+    HYBRID_LEECH: bool = False
+    HYDRA_IP: str = ""
+    HYDRA_API_KEY: str = ""
+    NAME_SUBSTITUTE: str = ""
+    OWNER_ID: int = 0
+    QUEUE_ALL: int = 0
+    QUEUE_DOWNLOAD: int = 0
+    QUEUE_UPLOAD: int = 0
+    RCLONE_FLAGS: str = ""
+    RCLONE_PATH: str = ""
+    RCLONE_SERVE_URL: str = ""
+    RCLONE_SERVE_USER: str = ""
+    RCLONE_SERVE_PASS: str = ""
+    RCLONE_SERVE_PORT: int = 8080
+    RSS_CHAT: str = ""
+    RSS_DELAY: int = 600
+    RSS_SIZE_LIMIT: int = 0
+    SEARCH_API_LINK: str = ""
+    SEARCH_LIMIT: int = 0
+    SEARCH_PLUGINS: List[str] = []
+    STATUS_LIMIT: int = 4
+    STATUS_UPDATE_INTERVAL: int = 15
+    STOP_DUPLICATE: bool = False
+    STREAMWISH_API: str = ""
+    SUDO_USERS: str = ""
+    TELEGRAM_API: int = 0
+    TELEGRAM_HASH: str = ""
+    TG_PROXY: Dict[str, Any] = {}
+    THUMBNAIL_LAYOUT: str = ""
+    TORRENT_TIMEOUT: int = 0
+    UPLOAD_PATHS: Dict[str, str] = {}
+    UPSTREAM_REPO: str = ""
+    UPSTREAM_BRANCH: str = "master"
+    USENET_SERVERS: List[Dict[str, Any]] = []
+    USER_SESSION_STRING: str = ""
+    USER_TRANSMISSION: bool = False
+    USE_SERVICE_ACCOUNTS: bool = False
+    WEB_PINCODE: bool = False
+    YT_DLP_OPTIONS: Dict[str, Any] = {}
 
     @classmethod
-    def _convert(cls, key, value):
+    def _convert(cls, key: str, value: Any) -> Any:
+        """Convert value to the expected type for the given key."""
+        if not hasattr(cls, key):
+            raise KeyError(f"{key} is not a valid configuration key.")
+
         expected_type = type(getattr(cls, key))
+
         if value is None:
             return None
+
         if isinstance(value, expected_type):
             return value
 
-        if expected_type == bool:
+        if expected_type is bool:
             return str(value).strip().lower() in {"true", "1", "yes"}
 
         if expected_type in [list, dict]:
             if not isinstance(value, str):
-                raise TypeError(
-                    f"{key} should be {expected_type.__name__}, got {type(value).__name__}"
-                )
+                raise TypeError(f"{key} should be {expected_type.__name__}, got {type(value).__name__}")
 
             if not value:
                 return expected_type()
 
             try:
                 evaluated = literal_eval(value)
-                if isinstance(evaluated, expected_type):
-                    return evaluated
-                else:
-                    raise TypeError
+                if not isinstance(evaluated, expected_type):
+                    raise TypeError(f"Expected {expected_type.__name__}, got {type(evaluated).__name__}")
+                return evaluated
             except (ValueError, SyntaxError, TypeError) as e:
-                raise TypeError(
-                    f"{key} should be {expected_type.__name__}, got invalid string: {value}"
-                ) from e
+                raise TypeError(f"{key} should be {expected_type.__name__}, got invalid string: {value}") from e
+
         try:
             return expected_type(value)
         except (ValueError, TypeError) as exc:
-            raise TypeError(
-                f"Invalid type for {key}: expected {expected_type}, got {type(value)}"
-            ) from exc
+            raise TypeError(f"Invalid type for {key}: expected {expected_type}, got {type(value)}") from exc
 
     @classmethod
-    def get(cls, key):
-        return getattr(cls, key) if hasattr(cls, key) else None
+    def get(cls, key: str) -> Any:
+        """Get configuration value by key."""
+        return getattr(cls, key, None)
 
     @classmethod
-    def set(cls, key, value):
-        if hasattr(cls, key):
-            value = cls._convert(key, value)
-            setattr(cls, key, value)
-        else:
+    def set(cls, key: str, value: Any) -> None:
+        """Set configuration value by key."""
+        if not hasattr(cls, key):
             raise KeyError(f"{key} is not a valid configuration key.")
 
-    @classmethod
-    def get_all(cls):
-        return {
-            key: getattr(cls, key)
-            for key in cls.__dict__.keys()
-            if not key.startswith("__") and not callable(getattr(cls, key))
-        }
+        converted_value = cls._convert(key, value)
+        setattr(cls, key, converted_value)
 
     @classmethod
-    def load(cls):
+    def get_all(cls) -> Dict[str, Any]:
+        """Get all configuration values."""
+        return {key: getattr(cls, key) for key in cls.__dict__.keys() if not key.startswith("__") and not callable(getattr(cls, key))}
+
+    @classmethod
+    def _is_valid_config_attr(cls, attr: str) -> bool:
+        """Check if attribute is a valid config attribute."""
+        if attr.startswith("__") or callable(getattr(cls, attr, None)):
+            return False
+        return hasattr(cls, attr)
+
+    @classmethod
+    def _process_config_value(cls, attr: str, value: Any) -> Optional[Any]:
+        """Process and validate a config value."""
+        if not value:
+            return None
+
+        converted_value = cls._convert(attr, value)
+
+        if isinstance(converted_value, str):
+            converted_value = converted_value.strip()
+
+        # Apply specific transformations
+        if attr == "DEFAULT_UPLOAD" and converted_value != "gd":
+            return "rc"
+
+        if attr in ["BASE_URL", "RCLONE_SERVE_URL", "INDEX_URL", "SEARCH_API_LINK"]:
+            return converted_value.strip("/") if converted_value else ""
+
+        if attr == "USENET_SERVERS":
+            if not converted_value or not converted_value[0].get("host"):
+                return None
+
+        return converted_value
+
+    @classmethod
+    def _load_from_module(cls) -> bool:
+        """Load configuration from config module. Returns True if successful."""
         try:
-            # Try to load from config module first
             settings = import_module("config")
-            for attr in dir(settings):
-                if not attr.startswith("__") and not callable(getattr(settings, attr)) and hasattr(cls, attr):
-                    value = getattr(settings, attr)
-                    if not value:
-                        continue
-                    value = cls._convert(attr, value)
-                    if isinstance(value, str):
-                        value = value.strip()
-                    if attr == "DEFAULT_UPLOAD" and value != "gd":
-                        value = "rc"
-                    elif attr in [
-                        "BASE_URL",
-                        "RCLONE_SERVE_URL",
-                        "INDEX_URL",
-                        "SEARCH_API_LINK",
-                    ]:
-                        if value:
-                            value = value.strip("/")
-                    elif attr == "USENET_SERVERS":
-                        try:
-                            if not value[0].get("host"):
-                                continue
-                        except:
-                            continue
-                    setattr(cls, attr, value)
         except ModuleNotFoundError:
-            # if config not found, load from env
+            return False
+
+        for attr in dir(settings):
+            if not cls._is_valid_config_attr(attr):
+                continue
+
+            raw_value = getattr(settings, attr)
+            processed_value = cls._process_config_value(attr, raw_value)
+
+            if processed_value is not None:
+                setattr(cls, attr, processed_value)
+
+        return True
+
+    @classmethod
+    def _load_from_env(cls) -> None:
+        """Load configuration from environment variables."""
+        for attr in dir(cls):
+            if not cls._is_valid_config_attr(attr):
+                continue
+
+            env_value = os.getenv(attr)
+            if env_value is None:
+                continue
+
+            processed_value = cls._process_config_value(attr, env_value)
+            if processed_value is not None:
+                setattr(cls, attr, processed_value)
+
+    @classmethod
+    def _validate_required_config(cls) -> None:
+        """Validate that all required configuration is present."""
+        required_keys = ["BOT_TOKEN", "OWNER_ID", "TELEGRAM_API", "TELEGRAM_HASH"]
+
+        for key in required_keys:
+            value = getattr(cls, key)
+            if isinstance(value, str):
+                value = value.strip()
+            if not value:
+                raise ValueError(f"{key} variable is missing!")
+
+    @classmethod
+    def load(cls) -> None:
+        """Load configuration from config module or environment variables."""
+        if not cls._load_from_module():
             print("Config module not found, loading from environment variables...")
             cls._load_from_env()
 
-        for key in ["BOT_TOKEN", "OWNER_ID", "TELEGRAM_API", "TELEGRAM_HASH"]:
-            value = getattr(cls, key)
-            if isinstance(value, str):
-                value = value.strip()
-            if not value:
-                raise ValueError(f"{key} variable is missing!")
+        cls._validate_required_config()
 
     @classmethod
-    def _load_from_env(cls):
-        """Load configuration from environment variables"""
-        for attr in dir(cls):
-            if not attr.startswith("__") and not callable(getattr(cls, attr)) and hasattr(cls, attr):
-                env_value = os.getenv(attr)
-                if env_value is None:
-                    continue
-
-                value = cls._convert(attr, env_value)
-                if isinstance(value, str):
-                    value = value.strip()
-                if attr == "DEFAULT_UPLOAD" and value != "gd":
-                    value = "rc"
-                elif attr in [
-                    "BASE_URL",
-                    "RCLONE_SERVE_URL",
-                    "INDEX_URL",
-                    "SEARCH_API_LINK",
-                ]:
-                    if value:
-                        value = value.strip("/")
-                elif attr == "USENET_SERVERS":
-                    try:
-                        if not value[0].get("host"):
-                            continue
-                    except:
-                        continue
-                setattr(cls, attr, value)
-
-    @classmethod
-    def load_dict(cls, config_dict):
+    def load_dict(cls, config_dict: Dict[str, Any]) -> None:
+        """Load configuration from dictionary."""
         for key, value in config_dict.items():
-            if hasattr(cls, key):
-                value = cls._convert(key, value)
-                if key == "DEFAULT_UPLOAD" and value != "gd":
-                    value = "rc"
-                elif key in [
-                    "BASE_URL",
-                    "RCLONE_SERVE_URL",
-                    "INDEX_URL",
-                    "SEARCH_API_LINK",
-                ]:
-                    if value:
-                        value = value.strip("/")
-                elif key == "USENET_SERVERS":
-                    try:
-                        if not value[0].get("host"):
-                            value = []
-                    except:
-                        value = []
-                setattr(cls, key, value)
-        for key in ["BOT_TOKEN", "OWNER_ID", "TELEGRAM_API", "TELEGRAM_HASH"]:
-            value = getattr(cls, key)
-            if isinstance(value, str):
-                value = value.strip()
-            if not value:
-                raise ValueError(f"{key} variable is missing!")
+            if not hasattr(cls, key):
+                continue
+
+            processed_value = cls._process_config_value(key, value)
+
+            # Special handling for USENET_SERVERS in dict loading
+            if key == "USENET_SERVERS" and processed_value is None:
+                processed_value = []
+
+            if processed_value is not None:
+                setattr(cls, key, processed_value)
+
+        cls._validate_required_config()


### PR DESCRIPTION
Adds fallback to environment variables when config.py module is not found.
Changes:

- config_manager.py: Tries config module first, falls back to env vars if missing
- update.py: Same defensive approach for required variables


Zero breaking changes - existing config.py deployments work unchanged
Docker-friendly - users can now deploy with env vars only
Clean separation - no mixing of config sources

Usage:
```yaml
# docker-compose.yml
environment:
  - BOT_TOKEN=your_token
  - OWNER_ID=123456
  # ... other vars
  ```