### PR TITLE
Refactor RSS to not suck

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,8 +430,8 @@ see [Using Service Accounts](https://github.com/anasty17/mirror-leech-telegram-b
 
 - `RSS_SIZE_LIMIT` (`INT`): Item size limit in bytes. Default is `0`.
 
-- `RSS_CHAT` (`Int`|`Str`): Chat `ID or USERNAME or ID|TOPIC_ID or USERNAME|TOPIC_ID` where rss links will be sent. If you want message to be sent to the channel then add channel id. Add `-100` before channel id.
-    - **RSS NOTES**: `RSS_CHAT` is required, otherwise monitor will not work. You must use `USER_STRING_SESSION` --OR-- *CHANNEL*. If using channel then bot should be added in both channel and group(linked to channel) and `RSS_CHAT` is the channel id, so messages sent by the bot to channel will be forwarded to group. Otherwise with `USER_STRING_SESSION` add group id for `RSS_CHAT`. If `DATABASE_URL` not added you will miss the feeds while bot offline.
+- `RSS_CHAT` (`Int`|`Str`): Chat `ID or USERNAME or ID|TOPIC_ID or USERNAME|TOPIC_ID` where RSS download results and notifications are posted. The bot must be a member of this chat. Can be a group, supergroup, or user chat. No channel/linked-group setup or `USER_SESSION_STRING` is required. When a command is configured for a subscription (e.g., `-c ql -doc`), downloads start automatically and results are posted here. Without a command, only feed info (name, link, size) is posted.
+    - **RSS NOTES**: `RSS_CHAT` is required, otherwise the RSS monitor will not work. If `DATABASE_URL` is not added you will miss feeds while the bot is offline.
 
 **11. Queue System**
 

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -119,7 +119,7 @@ class TaskConfig:
         self.is_file = False
         self.bot_trans = False
         self.user_trans = False
-        self.is_rss = False
+        self.is_rss = getattr(self.message, "_rss_trigger", False)
         self.progress = True
         self.ffmpeg_cmds = None
         self.chat_thread_id = None
@@ -541,21 +541,6 @@ class TaskConfig:
                 )
 
     async def get_tag(self, text: list):
-        if len(text) > 1 and text[1].startswith("Tag: "):
-            self.is_rss = True
-            user_info = text[1].split("Tag: ")
-            if len(user_info) >= 3:
-                id_ = user_info[-1]
-                self.tag = " ".join(user_info[:-1])
-            else:
-                self.tag, id_ = text[1].split("Tag: ")[1].split()
-            self.user = self.message.from_user = await self.client.get_users(int(id_))
-            self.user_id = self.user.id
-            self.user_dict = user_data.get(self.user_id, {})
-            try:
-                await self.message.unpin()
-            except:
-                pass
         if self.user:
             if username := self.user.username:
                 self.tag = f"@{username}"
@@ -704,7 +689,6 @@ class TaskConfig:
                     or is_archive(file_)
                     and not file_.strip().lower().endswith(".rar")
                 ):
-
                     self.proceed_count += 1
                     f_path = ospath.join(dirpath, file_)
                     t_path = get_base_name(f_path) if self.is_file else dirpath

--- a/bot/helper/telegram_helper/message_utils.py
+++ b/bot/helper/telegram_helper/message_utils.py
@@ -62,8 +62,7 @@ async def send_file(message, file, caption=""):
 
 async def send_rss(text, chat_id, thread_id):
     try:
-        app = TgClient.user or TgClient.bot
-        return await app.send_message(
+        return await TgClient.bot.send_message(
             chat_id=chat_id,
             text=text,
             message_thread_id=thread_id,

--- a/bot/modules/rss.py
+++ b/bot/modules/rss.py
@@ -12,6 +12,7 @@ from re import compile, I
 
 from .. import scheduler, rss_dict, LOGGER
 from ..core.config_manager import Config
+from ..core.telegram_manager import TgClient
 from ..helper.ext_utils.bot_utils import new_task, arg_parser, get_size_bytes
 from ..helper.ext_utils.status_utils import get_readable_file_size
 from ..helper.ext_utils.db_handler import database
@@ -26,6 +27,7 @@ from ..helper.telegram_helper.message_utils import (
     send_file,
     delete_message,
 )
+
 
 rss_dict_lock = Lock()
 handler_dict = {}
@@ -44,6 +46,119 @@ Title2 -c none -inf none -stv false
 Title3 -c mirror -rcf xxx -up xxx -z pswd -stv false
 Note: Only what you provide will be edited, the rest will be the same like example 2: exf will stay same as it is.
 Timeout: 60 sec. Argument -c for command and arguments"""
+
+
+def _find_command_filters(flt):
+    """Recursively extract CommandFilter instances from a composite filter tree."""
+    # Check if this filter has .commands (it's a CommandFilter)
+    if hasattr(flt, "commands"):
+        yield flt
+    # Traverse AndFilter / OrFilter composites
+    for attr in ("base", "other"):
+        if child := getattr(flt, attr, None):
+            yield from _find_command_filters(child)
+
+
+def _build_command_map() -> dict:
+    """Build a mapping from command name -> handler callback by inspecting
+    the bot's registered message handlers.
+
+    This stays in sync automatically — any handler registered via
+    add_handler() is discovered here.
+    """
+    from pyrogram.handlers import MessageHandler
+
+    mapping = {}
+    for group in TgClient.bot.dispatcher.groups.values():
+        for handler in group:
+            if not isinstance(handler, MessageHandler):
+                continue
+            if handler.filters is None:
+                continue
+            for cmd_filter in _find_command_filters(handler.filters):
+                for cmd in cmd_filter.commands:
+                    mapping[cmd] = handler.callback
+    return mapping
+
+
+_command_map: dict | None = None
+
+
+def _get_command_map() -> dict:
+    global _command_map
+    if _command_map is None:
+        _command_map = _build_command_map()
+    return _command_map
+
+
+def _resolve_command(command_str: str):
+    """Resolve a command string like 'ql -doc' into its handler function.
+
+    Returns the handler function, or None if not recognized.
+    Handles commands with or without CMD_SUFFIX.
+    """
+    cmd_name = command_str.strip().lstrip("/").split(maxsplit=1)[0]
+    mapping = _get_command_map()
+    handler = mapping.get(cmd_name)
+    if handler is None and Config.CMD_SUFFIX:
+        # Try with suffix appended (e.g. user stored "ql" but commands are "qlbot")
+        handler = mapping.get(cmd_name + Config.CMD_SUFFIX)
+    if handler is None:
+        LOGGER.warning(f"RSS: Unknown command '{cmd_name}' (from '{command_str}')")
+    return handler
+
+
+async def _start_rss_download(
+    url: str,
+    command: str,
+    user_id: int,
+    rss_chat_id,
+    rss_topic_id,
+    item_title: str,
+) -> None:
+    """Send a notification to RSS_CHAT and start the download directly."""
+    handler = _resolve_command(command)
+    if handler is None:
+        LOGGER.error(f"RSS: Cannot start download, unknown command: {command}")
+        return
+
+    # Build the command text that the handler will parse.
+    # command is like "ql -doc" or "mirror -up remote:path".
+    # The handler expects message.text = "/cmd url [args]"
+    cmd_text = f"/{command.strip().lstrip('/')}"
+    # Insert URL after the command name
+    parts = cmd_text.split(maxsplit=1)
+    if len(parts) > 1:
+        cmd_text = f"{parts[0]} {url} {parts[1]}"
+    else:
+        cmd_text = f"{parts[0]} {url}"
+
+    # Resolve the user who subscribed to this feed
+    try:
+        user = await TgClient.bot.get_users(user_id)
+    except Exception as e:
+        LOGGER.error(
+            f"RSS: Failed to get user {user_id}, "
+            f"cannot start download for '{item_title}': {e}"
+        )
+        return
+
+    # Send notification to RSS_CHAT — this also provides the Message object
+    # that the download pipeline uses for posting status/results
+    notify_text = f"<b>RSS Download Started</b>\n<code>{escape_html(item_title)}</code>"
+    msg = await send_rss(notify_text, rss_chat_id, rss_topic_id)
+    if isinstance(msg, str):
+        LOGGER.error(f"RSS: Failed to send to RSS_CHAT: {msg}")
+        return
+
+    # Mutate the message to carry the command text and user identity
+    msg.text = cmd_text
+    msg.from_user = user
+    msg._rss_trigger = True
+
+    # Invoke the same handler function used by the bot's message handlers
+    # (e.g., mirror, leech, qb_leech, ytdl, etc.)
+    await handler(TgClient.bot, msg)
 
 
 # ======================== Helper Functions ========================
@@ -881,23 +996,27 @@ async def _process_feed_entry(
     if not check_filters(item_title, data):
         return True
 
-    # Build and send message
+    # Handle feed item
     if command := data["command"]:
+        # Auto-download mode: start download directly
         if size and Config.RSS_SIZE_LIMIT and Config.RSS_SIZE_LIMIT < size:
             return True
-        cmd = command.split(maxsplit=1)
-        cmd.insert(1, url)
-        feed_msg = " ".join(cmd)
-        if not feed_msg.startswith("/"):
-            feed_msg = f"/{feed_msg}"
+        await _start_rss_download(
+            url=url,
+            command=command,
+            user_id=user,
+            rss_chat_id=rss_chat_id,
+            rss_topic_id=rss_topic_id,
+            item_title=item_title,
+        )
     else:
+        # Info-only mode: just post item details to RSS_CHAT
         feed_msg = f"<b>Name: </b><code>{escape_html(item_title)}</code>"
         feed_msg += f"\n\n<b>Link: </b><code>{url}</code>"
         if size:
             feed_msg += f"\n<b>Size: </b>{get_readable_file_size(size)}"
-
-    feed_msg += f"\n<b>Tag: </b><code>{data['tag']}</code> <code>{user}</code>"
-    await send_rss(feed_msg, rss_chat_id, rss_topic_id)
+        feed_msg += f"\n<b>Tag: </b><code>{data['tag']}</code> <code>{user}</code>"
+        await send_rss(feed_msg, rss_chat_id, rss_topic_id)
     return True
 
 
@@ -952,7 +1071,7 @@ async def _process_feed(
 async def rss_monitor() -> None:
     chat = Config.RSS_CHAT
     if not chat:
-        LOGGER.warning("RSS_CHAT not added! Shutting down rss scheduler...")
+        LOGGER.warning("RSS_CHAT not configured! Shutting down rss scheduler...")
         scheduler.shutdown(wait=False)
         return
 

--- a/bot/modules/rss.py
+++ b/bot/modules/rss.py
@@ -28,46 +28,29 @@ from ..helper.telegram_helper.message_utils import (
     delete_message,
 )
 
-
 rss_dict_lock = Lock()
 handler_dict = {}
-SIZE_REGEX = compile(r"(\d+(\.\d+)?\s?(GB|MB|KB|GiB|MiB|KiB))", I)
+size_regex = compile(r"(\d+(\.\d+)?\s?(GB|MB|KB|GiB|MiB|KiB))", I)
 
-HEADERS = {
+headers = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36",
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
     "Accept-Language": "en-US,en;q=0.5",
 }
 
-RSS_EDIT_HELP = """Send one or more rss titles with new filters or command separated by new line.
-Examples:
-Title1 -c mirror -up remote:path/subdir -exf none -inf 1080 or 720 -stv true
-Title2 -c none -inf none -stv false
-Title3 -c mirror -rcf xxx -up xxx -z pswd -stv false
-Note: Only what you provide will be edited, the rest will be the same like example 2: exf will stay same as it is.
-Timeout: 60 sec. Argument -c for command and arguments"""
-
 
 def _find_command_filters(flt):
     """Recursively extract CommandFilter instances from a composite filter tree."""
-    # Check if this filter has .commands (it's a CommandFilter)
     if hasattr(flt, "commands"):
         yield flt
-    # Traverse AndFilter / OrFilter composites
     for attr in ("base", "other"):
         if child := getattr(flt, attr, None):
             yield from _find_command_filters(child)
 
 
-def _build_command_map() -> dict:
+def _build_command_map():
     """Build a mapping from command name -> handler callback by inspecting
-    the bot's registered message handlers.
-
-    This stays in sync automatically — any handler registered via
-    add_handler() is discovered here.
-    """
-    from pyrogram.handlers import MessageHandler
-
+    the bot's registered message handlers."""
     mapping = {}
     for group in TgClient.bot.dispatcher.groups.values():
         for handler in group:
@@ -81,17 +64,17 @@ def _build_command_map() -> dict:
     return mapping
 
 
-_command_map: dict | None = None
+_command_map = None
 
 
-def _get_command_map() -> dict:
+def _get_command_map():
     global _command_map
     if _command_map is None:
         _command_map = _build_command_map()
     return _command_map
 
 
-def _resolve_command(command_str: str):
+def _resolve_command(command_str):
     """Resolve a command string like 'ql -doc' into its handler function.
 
     Returns the handler function, or None if not recognized.
@@ -101,7 +84,6 @@ def _resolve_command(command_str: str):
     mapping = _get_command_map()
     handler = mapping.get(cmd_name)
     if handler is None and Config.CMD_SUFFIX:
-        # Try with suffix appended (e.g. user stored "ql" but commands are "qlbot")
         handler = mapping.get(cmd_name + Config.CMD_SUFFIX)
     if handler is None:
         LOGGER.warning(f"RSS: Unknown command '{cmd_name}' (from '{command_str}')")
@@ -109,31 +91,21 @@ def _resolve_command(command_str: str):
 
 
 async def _start_rss_download(
-    url: str,
-    command: str,
-    user_id: int,
-    rss_chat_id,
-    rss_topic_id,
-    item_title: str,
-) -> None:
+    url, command, user_id, rss_chat_id, rss_topic_id, item_title
+):
     """Send a notification to RSS_CHAT and start the download directly."""
     handler = _resolve_command(command)
     if handler is None:
         LOGGER.error(f"RSS: Cannot start download, unknown command: {command}")
         return
 
-    # Build the command text that the handler will parse.
-    # command is like "ql -doc" or "mirror -up remote:path".
-    # The handler expects message.text = "/cmd url [args]"
     cmd_text = f"/{command.strip().lstrip('/')}"
-    # Insert URL after the command name
     parts = cmd_text.split(maxsplit=1)
     if len(parts) > 1:
         cmd_text = f"{parts[0]} {url} {parts[1]}"
     else:
         cmd_text = f"{parts[0]} {url}"
 
-    # Resolve the user who subscribed to this feed
     try:
         user = await TgClient.bot.get_users(user_id)
     except Exception as e:
@@ -143,136 +115,20 @@ async def _start_rss_download(
         )
         return
 
-    # Send notification to RSS_CHAT — this also provides the Message object
-    # that the download pipeline uses for posting status/results
-    notify_text = f"<b>RSS Download Started</b>\n<code>{escape_html(item_title)}</code>"
+    notify_text = f"<b>RSS Download Started</b>\n<code>{item_title.replace('>', '').replace('<', '')}</code>"
     msg = await send_rss(notify_text, rss_chat_id, rss_topic_id)
     if isinstance(msg, str):
         LOGGER.error(f"RSS: Failed to send to RSS_CHAT: {msg}")
         return
 
-    # Mutate the message to carry the command text and user identity
     msg.text = cmd_text
     msg.from_user = user
     msg._rss_trigger = True
 
-    # Invoke the same handler function used by the bot's message handlers
-    # (e.g., mirror, leech, qb_leech, ytdl, etc.)
     await handler(TgClient.bot, msg)
 
 
-# ======================== Helper Functions ========================
-
-
-async def fetch_rss(url: str, retries: int = 3) -> str | None:
-    """Fetch RSS feed with retries."""
-    for attempt in range(retries + 1):
-        try:
-            async with AsyncClient(
-                headers=HEADERS, follow_redirects=True, timeout=60, verify=False
-            ) as client:
-                res = await client.get(url)
-            return res.text
-        except Exception:
-            if attempt >= retries:
-                raise
-    return None
-
-
-def get_entry_link(entry: dict) -> str:
-    """Extract link from RSS entry."""
-    links = entry.get("links", [])
-    if len(links) > 1:
-        return links[1].get("href", "")
-    if links:
-        return links[0].get("href", "")
-    return entry.get("link", "")
-
-
-def get_entry_size(entry: dict) -> int:
-    """Extract size from RSS entry."""
-    if entry.get("size"):
-        return int(entry["size"])
-    if summary := entry.get("summary"):
-        if matches := SIZE_REGEX.findall(summary):
-            return get_size_bytes(matches[0][0])
-    return 0
-
-
-def parse_filters(filter_str: str | None) -> list[list[str]]:
-    """Parse filter string into list of filter groups."""
-    if not filter_str:
-        return []
-    return [x.split(" or ") for x in filter_str.split("|")]
-
-
-def check_filters(item_title: str, data: dict) -> bool:
-    """Check if item passes include/exclude filters. Returns True if item should be processed."""
-    sensitive = data.get("sensitive", False)
-
-    def matches(term: str, title: str) -> bool:
-        if sensitive:
-            return term.lower() in title.lower()
-        return term in title
-
-    # Check include filters - at least one term in each group must match
-    for flist in data["inf"]:
-        if all(not matches(term, item_title) for term in flist):
-            return False
-
-    # Check exclude filters - if any term matches, exclude
-    for flist in data["exf"]:
-        if any(matches(term, item_title) for term in flist):
-            return False
-
-    return True
-
-
-def parse_chat_id(chat: int | str) -> tuple[int | str | None, int | str | None]:
-    """Parse RSS_CHAT config into chat_id and topic_id."""
-    if isinstance(chat, int):
-        return chat, None
-    if "|" in chat:
-        parts = chat.split("|", 1)
-        chat_id = int(parts[0]) if parts[0].lstrip("-").isdigit() else parts[0]
-        topic_id = int(parts[1]) if parts[1].lstrip("-").isdigit() else parts[1]
-        return chat_id, topic_id
-    if chat.lstrip("-").isdigit():
-        return int(chat), None
-    return None, None
-
-
-def build_back_close_buttons(user_id: int) -> ButtonMaker:
-    """Create standard back/close button layout."""
-    buttons = ButtonMaker()
-    buttons.data_button("Back", f"rss back {user_id}")
-    buttons.data_button("Close", f"rss close {user_id}")
-    return buttons
-
-
-def format_feed_info(title: str, data: dict, show_user: bool = False) -> str:
-    """Format feed information for display."""
-    info = f"\n\n<b>Title:</b> <code>{title}</code>\n"
-    info += f"<b>Feed Url:</b> <code>{data['link']}</code>\n"
-    info += f"<b>Command:</b> <code>{data['command']}</code>\n"
-    info += f"<b>Inf:</b> <code>{data['inf']}</code>\n"
-    info += f"<b>Exf:</b> <code>{data['exf']}</code>\n"
-    info += f"<b>Sensitive:</b> <code>{data.get('sensitive', False)}</code>\n"
-    info += f"<b>Paused:</b> <code>{data['paused']}</code>\n"
-    if show_user:
-        info += f"<b>User:</b> {data['tag'].replace('@', '', 1)}"
-    return info
-
-
-def escape_html(text: str) -> str:
-    """Escape < and > for HTML display."""
-    return text.replace(">", "").replace("<", "")
-
-
-# ======================== Menu Functions ========================
-
-
-async def rss_menu(event) -> tuple[str, list]:
+async def rss_menu(event):
     user_id = event.from_user.id
     buttons = ButtonMaker()
     buttons.data_button("Subscribe", f"rss sub {user_id}")
@@ -282,234 +138,227 @@ async def rss_menu(event) -> tuple[str, list]:
     buttons.data_button("Pause", f"rss pause {user_id}")
     buttons.data_button("Resume", f"rss resume {user_id}")
     buttons.data_button("Unsubscribe", f"rss unsubscribe {user_id}")
-
     if await CustomFilters.sudo("", event):
         buttons.data_button("All Subscriptions", f"rss listall {user_id} 0")
         buttons.data_button("Pause All", f"rss allpause {user_id}")
         buttons.data_button("Resume All", f"rss allresume {user_id}")
         buttons.data_button("Unsubscribe All", f"rss allunsub {user_id}")
         buttons.data_button("Delete User", f"rss deluser {user_id}")
-        btn_text = "Shutdown Rss" if scheduler.running else "Start Rss"
-        btn_data = "shutdown" if scheduler.running else "start"
-        buttons.data_button(btn_text, f"rss {btn_data} {user_id}")
-
+        if scheduler.running:
+            buttons.data_button("Shutdown Rss", f"rss shutdown {user_id}")
+        else:
+            buttons.data_button("Start Rss", f"rss start {user_id}")
     buttons.data_button("Close", f"rss close {user_id}")
-    return (
-        f"Rss Menu | Users: {len(rss_dict)} | Running: {scheduler.running}",
-        buttons.build_menu(2),
-    )
+    button = buttons.build_menu(2)
+    msg = f"Rss Menu | Users: {len(rss_dict)} | Running: {scheduler.running}"
+    return msg, button
 
 
-async def update_rss_menu(query) -> None:
+async def update_rss_menu(query):
     msg, button = await rss_menu(query)
     await edit_message(query.message, msg, button)
 
 
 @new_task
-async def get_rss_menu(_, message) -> None:
+async def get_rss_menu(_, message):
     msg, button = await rss_menu(message)
     await send_message(message, msg, button)
 
 
-# ======================== Subscription Functions ========================
-
-
-async def _process_subscription(
-    message, title: str, feed_link: str, args: list, tag: str, user_id: int
-) -> str | None:
-    """Process a single RSS subscription. Returns message string on success, None on failure."""
-    # Parse arguments
-    arg_base = {"-c": None, "-inf": None, "-exf": None, "-stv": None}
-    if len(args) > 2:
-        arg_parser(args[2:], arg_base)
-
-    cmd = arg_base["-c"]
-    inf = arg_base["-inf"]
-    exf = arg_base["-exf"]
-    stv = arg_base["-stv"]
-    stv = stv.lower() == "true" if stv is not None else False
-
-    inf_lists = parse_filters(inf)
-    exf_lists = parse_filters(exf)
-
-    try:
-        html = await fetch_rss(feed_link)
-        rss_d = feed_parse(html)
-
-        last_link = ""
-        last_title = ""
-        size = 0
-        feed_title = rss_d.feed.get("title", "Unknown")
-
-        if rss_d.entries:
-            entry = rss_d.entries[0]
-            last_title = entry["title"]
-            last_link = get_entry_link(entry)
-            size = get_entry_size(entry)
-
-        # Build response message
-        msg = "<b>Subscribed!</b>"
-        msg += f"\n<b>Title: </b><code>{title}</code>\n<b>Feed Url: </b>{feed_link}"
-
-        if rss_d.entries:
-            msg += f"\n<b>latest record for </b>{feed_title}:"
-            msg += f"\nName: <code>{escape_html(last_title)}</code>"
-            msg += f"\n<b>Link: </b><code>{last_link}</code>"
-            if size:
-                msg += f"\nSize: {get_readable_file_size(size)}"
-        else:
-            msg += "\n<b>Note:</b> Feed is currently empty, will be monitored for new items."
-
-        msg += f"\n<b>Command: </b><code>{cmd}</code>"
-        msg += f"\n<b>Filters:-</b>\ninf: <code>{inf}</code>\nexf: <code>{exf}</code>\n<b>sensitive: </b>{stv}"
-
-        # Store subscription
-        feed_data = {
-            "link": feed_link,
-            "last_feed": last_link,
-            "last_title": last_title,
-            "inf": inf_lists,
-            "exf": exf_lists,
-            "paused": False,
-            "command": cmd,
-            "sensitive": stv,
-            "tag": tag,
-        }
-
-        async with rss_dict_lock:
-            if user_id not in rss_dict:
-                rss_dict[user_id] = {}
-            rss_dict[user_id][title] = feed_data
-
-        LOGGER.info(
-            f"Rss Feed Added: id: {user_id} - title: {title} - link: {feed_link} - c: {cmd} - inf: {inf} - exf: {exf} - stv: {stv}"
-        )
-        return msg
-
-    except (IndexError, AttributeError) as e:
-        await send_message(
-            message,
-            f"The link: {feed_link} doesn't seem to be a RSS feed or it's region-blocked!\nError: {e}",
-        )
-    except Exception as e:
-        await send_message(message, str(e))
-    return None
-
-
 @new_task
-async def rss_sub(_, message, pre_event) -> None:
+async def rss_sub(_, message, pre_event):
     user_id = message.from_user.id
     handler_dict[user_id] = False
-    tag = (
-        f"@{message.from_user.username}"
-        if message.from_user.username
-        else message.from_user.mention
-    )
-
-    result_msg = ""
-    for index, item in enumerate(message.text.split("\n"), start=1):
+    if username := message.from_user.username:
+        tag = f"@{username}"
+    else:
+        tag = message.from_user.mention
+    msg = ""
+    items = message.text.split("\n")
+    for index, item in enumerate(items, start=1):
         args = item.split()
-
         if len(args) < 2:
             await send_message(
                 message,
                 f"{item}. Wrong Input format. Read help message before adding new subscription!",
             )
             continue
-
         title = args[0].strip()
-        if (user_feeds := rss_dict.get(user_id)) and title in user_feeds:
+        if (user_feeds := rss_dict.get(user_id, False)) and title in user_feeds:
             await send_message(
                 message, f"This title {title} already subscribed! Choose another title!"
             )
             continue
-
         feed_link = args[1].strip()
         if feed_link.startswith(("-inf", "-exf", "-c")):
             await send_message(
-                message, f"Wrong input in line {index}! Add Title! Read the example!"
+                message,
+                f"Wrong input in line {index}! Add Title! Read the example!",
             )
             continue
-
-        if sub_msg := await _process_subscription(
-            message, title, feed_link, args, tag, user_id
-        ):
-            result_msg += sub_msg
-
-    if result_msg:
+        inf_lists = []
+        exf_lists = []
+        if len(args) > 2:
+            arg_base = {"-c": None, "-inf": None, "-exf": None, "-stv": None}
+            arg_parser(args[2:], arg_base)
+            cmd = arg_base["-c"]
+            inf = arg_base["-inf"]
+            exf = arg_base["-exf"]
+            stv = arg_base["-stv"]
+            if stv is not None:
+                stv = stv.lower() == "true"
+            if inf is not None:
+                filters_list = inf.split("|")
+                for x in filters_list:
+                    y = x.split(" or ")
+                    inf_lists.append(y)
+            if exf is not None:
+                filters_list = exf.split("|")
+                for x in filters_list:
+                    y = x.split(" or ")
+                    exf_lists.append(y)
+        else:
+            inf = None
+            exf = None
+            cmd = None
+            stv = False
+        try:
+            async with AsyncClient(
+                headers=headers, follow_redirects=True, timeout=60, verify=False
+            ) as client:
+                res = await client.get(feed_link)
+            html = res.text
+            rss_d = feed_parse(html)
+            last_link = ""
+            last_title = ""
+            size = 0
+            feed_title = rss_d.feed.get("title", "Unknown")
+            if rss_d.entries:
+                last_title = rss_d.entries[0]["title"]
+                if rss_d.entries[0].get("size"):
+                    size = int(rss_d.entries[0]["size"])
+                elif rss_d.entries[0].get("summary"):
+                    summary = rss_d.entries[0]["summary"]
+                    matches = size_regex.findall(summary)
+                    sizes = [match[0] for match in matches]
+                    size = get_size_bytes(sizes[0])
+                try:
+                    last_link = rss_d.entries[0]["links"][1]["href"]
+                except IndexError:
+                    last_link = rss_d.entries[0]["link"]
+            msg += "<b>Subscribed!</b>"
+            msg += f"\n<b>Title: </b><code>{title}</code>\n<b>Feed Url: </b>{feed_link}"
+            if rss_d.entries:
+                msg += f"\n<b>latest record for </b>{feed_title}:"
+                msg += f"\nName: <code>{last_title.replace('>', '').replace('<', '')}</code>"
+                msg += f"\n<b>Link: </b><code>{last_link}</code>"
+                if size:
+                    msg += f"\nSize: {get_readable_file_size(size)}"
+            else:
+                msg += "\n<b>Note:</b> Feed is currently empty, will be monitored for new items."
+            msg += f"\n<b>Command: </b><code>{cmd}</code>"
+            msg += f"\n<b>Filters:-</b>\ninf: <code>{inf}</code>\nexf: <code>{exf}</code>\n<b>sensitive: </b>{stv}"
+            async with rss_dict_lock:
+                if rss_dict.get(user_id, False):
+                    rss_dict[user_id][title] = {
+                        "link": feed_link,
+                        "last_feed": last_link,
+                        "last_title": last_title,
+                        "inf": inf_lists,
+                        "exf": exf_lists,
+                        "paused": False,
+                        "command": cmd,
+                        "sensitive": stv,
+                        "tag": tag,
+                    }
+                else:
+                    rss_dict[user_id] = {
+                        title: {
+                            "link": feed_link,
+                            "last_feed": last_link,
+                            "last_title": last_title,
+                            "inf": inf_lists,
+                            "exf": exf_lists,
+                            "paused": False,
+                            "command": cmd,
+                            "sensitive": stv,
+                            "tag": tag,
+                        }
+                    }
+            LOGGER.info(
+                f"Rss Feed Added: id: {user_id} - title: {title} - link: {feed_link} - c: {cmd} - inf: {inf} - exf: {exf} - stv: {stv}"
+            )
+        except (IndexError, AttributeError) as e:
+            emsg = f"The link: {feed_link} doesn't seem to be a RSS feed or it's region-blocked!"
+            await send_message(message, emsg + "\nError: " + str(e))
+        except Exception as e:
+            await send_message(message, str(e))
+    if msg:
         await database.rss_update(user_id)
-        await send_message(message, result_msg)
+        await send_message(message, msg)
         is_sudo = await CustomFilters.sudo("", message)
         if scheduler.state == 2:
             scheduler.resume()
         elif is_sudo and not scheduler.running:
             add_job()
             scheduler.start()
-
     await update_rss_menu(pre_event)
 
 
-# ======================== Update Functions ========================
-
-
-async def get_user_id(title: str) -> tuple[bool, int | bool]:
+async def get_user_id(title):
     async with rss_dict_lock:
         return next(
-            ((True, user_id) for user_id, feeds in rss_dict.items() if title in feeds),
+            (
+                (True, user_id)
+                for user_id, feed in rss_dict.items()
+                if feed["title"] == title
+            ),
             (False, False),
         )
 
 
 @new_task
-async def rss_update(_, message, pre_event, state: str) -> None:
+async def rss_update(_, message, pre_event, state):
     user_id = message.from_user.id
     handler_dict[user_id] = False
+    titles = message.text.split()
     is_sudo = await CustomFilters.sudo("", message)
     updated = []
-
-    for title in message.text.split():
+    for title in titles:
         title = title.strip()
-        current_user_id = user_id
-
-        if not rss_dict.get(current_user_id, {}).get(title):
+        if not (res := rss_dict[user_id].get(title, False)):
             if is_sudo:
-                found, current_user_id = await get_user_id(title)
-                if not found:
-                    await send_message(message, f"{title} not found!")
-                    continue
-            else:
+                res, user_id = await get_user_id(title)
+            if not res:
+                user_id = message.from_user.id
                 await send_message(message, f"{title} not found!")
                 continue
-
-        is_paused = rss_dict[current_user_id][title].get("paused", False)
-        if (is_paused and state == "pause") or (not is_paused and state == "resume"):
+        istate = rss_dict[user_id][title].get("paused", False)
+        if istate and state == "pause" or not istate and state == "resume":
             await send_message(message, f"{title} already {state}d!")
             continue
-
         async with rss_dict_lock:
             updated.append(title)
             if state == "unsubscribe":
-                del rss_dict[current_user_id][title]
-            else:
-                rss_dict[current_user_id][title]["paused"] = state == "pause"
-
+                del rss_dict[user_id][title]
+            elif state == "pause":
+                rss_dict[user_id][title]["paused"] = True
+            elif state == "resume":
+                rss_dict[user_id][title]["paused"] = False
         if state == "resume":
             if scheduler.state == 2:
                 scheduler.resume()
             elif is_sudo and not scheduler.running:
                 add_job()
                 scheduler.start()
-
-        if is_sudo and Config.DATABASE_URL and current_user_id != user_id:
-            await database.rss_update(current_user_id)
-
-        if not rss_dict.get(current_user_id):
+        if is_sudo and Config.DATABASE_URL and user_id != message.from_user.id:
+            await database.rss_update(user_id)
+        if not rss_dict[user_id]:
             async with rss_dict_lock:
-                del rss_dict[current_user_id]
-            await database.rss_delete(current_user_id)
+                del rss_dict[user_id]
+            await database.rss_delete(user_id)
             if not rss_dict:
                 await database.trunc_table("rss")
-
     if updated:
         LOGGER.info(f"Rss link with Title(s): {updated} has been {state}d!")
         await send_message(
@@ -518,185 +367,184 @@ async def rss_update(_, message, pre_event, state: str) -> None:
         )
         if rss_dict.get(user_id):
             await database.rss_update(user_id)
-
     await update_rss_menu(pre_event)
 
 
-# ======================== List Functions ========================
-
-
-async def rss_list(query, start: int, all_users: bool = False) -> None:
+async def rss_list(query, start, all_users=False):
     user_id = query.from_user.id
-    buttons = build_back_close_buttons(user_id)
-    page = start // 5
-
-    async with rss_dict_lock:
-        if all_users:
-            list_feed = f"<b>All subscriptions | Page: {page} </b>"
-            keys_count = sum(len(v) for v in rss_dict.values())
-            count = 0
+    buttons = ButtonMaker()
+    if all_users:
+        list_feed = f"<b>All subscriptions | Page: {int(start / 5)} </b>"
+        async with rss_dict_lock:
+            keysCount = sum(len(v.keys()) for v in rss_dict.values())
+            index = 0
             for titles in rss_dict.values():
-                for title, data in list(titles.items())[start : start + 5]:
-                    list_feed += format_feed_info(title, data, show_user=True)
-                    count += 1
-                    if count >= 5:
+                for index, (title, data) in enumerate(
+                    list(titles.items())[start : 5 + start]
+                ):
+                    list_feed += f"\n\n<b>Title:</b> <code>{title}</code>\n"
+                    list_feed += f"<b>Feed Url:</b> <code>{data['link']}</code>\n"
+                    list_feed += f"<b>Command:</b> <code>{data['command']}</code>\n"
+                    list_feed += f"<b>Inf:</b> <code>{data['inf']}</code>\n"
+                    list_feed += f"<b>Exf:</b> <code>{data['exf']}</code>\n"
+                    list_feed += f"<b>Sensitive:</b> <code>{data.get('sensitive', False)}</code>\n"
+                    list_feed += f"<b>Paused:</b> <code>{data['paused']}</code>\n"
+                    list_feed += f"<b>User:</b> {data['tag'].replace('@', '', 1)}"
+                    index += 1
+                    if index == 5:
                         break
-                if count >= 5:
-                    break
-        else:
-            list_feed = f"<b>Your subscriptions | Page: {page} </b>"
-            user_feeds = rss_dict.get(user_id, {})
-            keys_count = len(user_feeds)
-            for title, data in list(user_feeds.items())[start : start + 5]:
-                list_feed += format_feed_info(title, data, show_user=False)
-
-    if keys_count > 5:
-        for x in range(0, keys_count, 5):
+    else:
+        list_feed = f"<b>Your subscriptions | Page: {int(start / 5)} </b>"
+        async with rss_dict_lock:
+            keysCount = len(rss_dict.get(user_id, {}).keys())
+            for title, data in list(rss_dict[user_id].items())[start : 5 + start]:
+                list_feed += f"\n\n<b>Title:</b> <code>{title}</code>\n<b>Feed Url: </b><code>{data['link']}</code>\n"
+                list_feed += f"<b>Command:</b> <code>{data['command']}</code>\n"
+                list_feed += f"<b>Inf:</b> <code>{data['inf']}</code>\n"
+                list_feed += f"<b>Exf:</b> <code>{data['exf']}</code>\n"
+                list_feed += (
+                    f"<b>Sensitive:</b> <code>{data.get('sensitive', False)}</code>\n"
+                )
+                list_feed += f"<b>Paused:</b> <code>{data['paused']}</code>\n"
+    buttons.data_button("Back", f"rss back {user_id}")
+    buttons.data_button("Close", f"rss close {user_id}")
+    if keysCount > 5:
+        for x in range(0, keysCount, 5):
             buttons.data_button(
-                f"{x // 5}", f"rss list {user_id} {x}", position="footer"
+                f"{int(x / 5)}", f"rss list {user_id} {x}", position="footer"
             )
-
     button = buttons.build_menu(2)
-    if query.message.text.html != list_feed:
-        await edit_message(query.message, list_feed, button)
-
-
-# ======================== Get/Edit Functions ========================
+    if query.message.text.html == list_feed:
+        return
+    await edit_message(query.message, list_feed, button)
 
 
 @new_task
-async def rss_get(_, message, pre_event) -> None:
+async def rss_get(_, message, pre_event):
     user_id = message.from_user.id
     handler_dict[user_id] = False
     args = message.text.split()
-
     if len(args) < 2:
         await send_message(
             message,
-            f"{args}. Wrong Input format. You should add number of the items you want to get.",
+            f"{args}. Wrong Input format. You should add number of the items you want to get. Read help message before adding new subscription!",
         )
         await update_rss_menu(pre_event)
         return
-
     try:
-        title, count = args[0], int(args[1])
-        data = rss_dict.get(user_id, {}).get(title)
-
-        if not data or count <= 0:
-            await send_message(message, "Enter a valid title. Title not found!")
-            await update_rss_menu(pre_event)
-            return
-
-        msg = await send_message(
-            message, f"Getting the last <b>{count}</b> item(s) from {title}"
-        )
-
-        try:
-            html = await fetch_rss(data["link"])
-            rss_d = feed_parse(html)
-
-            item_info = ""
-            for i in range(min(count, len(rss_d.entries))):
-                entry = rss_d.entries[i]
-                link = get_entry_link(entry)
-                item_info += (
-                    f"<b>Name: </b><code>{escape_html(entry['title'])}</code>\n"
+        title = args[0]
+        count = int(args[1])
+        data = rss_dict[user_id].get(title, False)
+        if data and count > 0:
+            try:
+                msg = await send_message(
+                    message, f"Getting the last <b>{count}</b> item(s) from {title}"
                 )
-                item_info += f"<b>Link: </b><code>{link}</code>\n\n"
-
-            if len(item_info.encode()) > 4000:
-                with BytesIO(item_info.encode()) as out_file:
-                    out_file.name = f"rssGet {title} items_no. {count}.txt"
-                    await send_file(message, out_file)
-                await delete_message(msg)
-            else:
-                await edit_message(msg, item_info)
-
-        except IndexError:
-            LOGGER.error("Parse depth exceeded")
-            await edit_message(
-                msg, "Parse depth exceeded. Try again with a lower value."
-            )
-        except Exception as e:
-            LOGGER.error(str(e))
-            await edit_message(msg, str(e))
-
+                async with AsyncClient(
+                    headers=headers, follow_redirects=True, timeout=60, verify=False
+                ) as client:
+                    res = await client.get(data["link"])
+                html = res.text
+                rss_d = feed_parse(html)
+                item_info = ""
+                for item_num in range(count):
+                    try:
+                        link = rss_d.entries[item_num]["links"][1]["href"]
+                    except IndexError:
+                        link = rss_d.entries[item_num]["link"]
+                    item_info += f"<b>Name: </b><code>{rss_d.entries[item_num]['title'].replace('>', '').replace('<', '')}</code>\n"
+                    item_info += f"<b>Link: </b><code>{link}</code>\n\n"
+                item_info_ecd = item_info.encode()
+                if len(item_info_ecd) > 4000:
+                    with BytesIO(item_info_ecd) as out_file:
+                        out_file.name = f"rssGet {title} items_no. {count}.txt"
+                        await send_file(message, out_file)
+                    await delete_message(msg)
+                else:
+                    await edit_message(msg, item_info)
+            except IndexError as e:
+                LOGGER.error(str(e))
+                await edit_message(
+                    msg, "Parse depth exceeded. Try again with a lower value."
+                )
+            except Exception as e:
+                LOGGER.error(str(e))
+                await edit_message(msg, str(e))
+        else:
+            await send_message(message, "Enter a valid title. Title not found!")
     except Exception as e:
         LOGGER.error(str(e))
         await send_message(message, f"Enter a valid value!. {e}")
-
     await update_rss_menu(pre_event)
 
 
 @new_task
-async def rss_edit(_, message, pre_event) -> None:
+async def rss_edit(_, message, pre_event):
     user_id = message.from_user.id
     handler_dict[user_id] = False
+    items = message.text.split("\n")
     updated = False
-
-    for item in message.text.split("\n"):
+    for item in items:
         args = item.split()
+        title = args[0].strip()
         if len(args) < 2:
             await send_message(
                 message,
                 f"{item}. Wrong Input format. Read help message before editing!",
             )
             continue
-
-        title = args[0].strip()
-        if not rss_dict.get(user_id, {}).get(title):
+        elif not rss_dict[user_id].get(title, False):
             await send_message(message, "Enter a valid title. Title not found!")
             continue
-
         updated = True
+        inf_lists = []
+        exf_lists = []
         arg_base = {"-c": None, "-inf": None, "-exf": None, "-stv": None}
         arg_parser(args[1:], arg_base)
-
+        cmd = arg_base["-c"]
+        inf = arg_base["-inf"]
+        exf = arg_base["-exf"]
+        stv = arg_base["-stv"]
         async with rss_dict_lock:
-            feed = rss_dict[user_id][title]
-
-            if arg_base["-stv"] is not None:
-                feed["sensitive"] = arg_base["-stv"].lower() == "true"
-
-            if arg_base["-c"] is not None:
-                feed["command"] = (
-                    None if arg_base["-c"].lower() == "none" else arg_base["-c"]
-                )
-
-            if arg_base["-inf"] is not None:
-                feed["inf"] = (
-                    []
-                    if arg_base["-inf"].lower() == "none"
-                    else parse_filters(arg_base["-inf"])
-                )
-
-            if arg_base["-exf"] is not None:
-                feed["exf"] = (
-                    []
-                    if arg_base["-exf"].lower() == "none"
-                    else parse_filters(arg_base["-exf"])
-                )
-
+            if stv is not None:
+                stv = stv.lower() == "true"
+                rss_dict[user_id][title]["sensitive"] = stv
+            if cmd is not None:
+                if cmd.lower() == "none":
+                    cmd = None
+                rss_dict[user_id][title]["command"] = cmd
+            if inf is not None:
+                if inf.lower() != "none":
+                    filters_list = inf.split("|")
+                    for x in filters_list:
+                        y = x.split(" or ")
+                        inf_lists.append(y)
+                rss_dict[user_id][title]["inf"] = inf_lists
+            if exf is not None:
+                if exf.lower() != "none":
+                    filters_list = exf.split("|")
+                    for x in filters_list:
+                        y = x.split(" or ")
+                        exf_lists.append(y)
+                rss_dict[user_id][title]["exf"] = exf_lists
     if updated:
         await database.rss_update(user_id)
     await update_rss_menu(pre_event)
 
 
 @new_task
-async def rss_delete(_, message, pre_event) -> None:
+async def rss_delete(_, message, pre_event):
     handler_dict[message.from_user.id] = False
-    for user in message.text.split():
-        user_id = int(user)
+    users = message.text.split()
+    for user in users:
+        user = int(user)
         async with rss_dict_lock:
-            del rss_dict[user_id]
-        await database.rss_delete(user_id)
+            del rss_dict[user]
+        await database.rss_delete(user)
     await update_rss_menu(pre_event)
 
 
-# ======================== Event Handler ========================
-
-
-async def event_handler(client, query, pfunc) -> None:
+async def event_handler(client, query, pfunc):
     user_id = query.from_user.id
     handler_dict[user_id] = True
     start_time = time()
@@ -708,399 +556,364 @@ async def event_handler(client, query, pfunc) -> None:
         )
 
     handler = client.add_handler(MessageHandler(pfunc, create(event_filter)), group=-1)
-
     while handler_dict[user_id]:
         await sleep(0.5)
         if time() - start_time > 60:
             handler_dict[user_id] = False
             await update_rss_menu(query)
-
     client.remove_handler(*handler)
 
 
-# ======================== Listener Handlers ========================
-
-
-async def _handle_close(query, user_id: int) -> None:
-    await query.answer()
-    handler_dict[user_id] = False
-    await delete_message(query.message.reply_to_message)
-    await delete_message(query.message)
-
-
-async def _handle_back(query, user_id: int) -> None:
-    await query.answer()
-    handler_dict[user_id] = False
-    await update_rss_menu(query)
-
-
-async def _handle_sub(client, query, user_id: int) -> None:
-    await query.answer()
-    handler_dict[user_id] = False
-    button = build_back_close_buttons(user_id).build_menu(2)
-    await edit_message(query.message, RSS_HELP_MESSAGE, button)
-    await event_handler(client, query, partial(rss_sub, pre_event=query))
-
-
-async def _handle_list(query, user_id: int, data: list[str]) -> None:
-    handler_dict[user_id] = False
-    if not rss_dict.get(int(data[2])):
-        await query.answer(text="No subscriptions!", show_alert=True)
-        return
-    await query.answer()
-    await rss_list(query, int(data[3]))
-
-
-async def _handle_get(client, query, user_id: int, data: list[str]) -> None:
-    handler_dict[user_id] = False
-    if not rss_dict.get(int(data[2])):
-        await query.answer(text="No subscriptions!", show_alert=True)
-        return
-    await query.answer()
-    button = build_back_close_buttons(user_id).build_menu(2)
-    await edit_message(
-        query.message,
-        "Send one title with value separated by space get last X items.\nTitle Value\nTimeout: 60 sec.",
-        button,
-    )
-    await event_handler(client, query, partial(rss_get, pre_event=query))
-
-
-async def _handle_feed_action(
-    client, query, user_id: int, data: list[str], action: str
-) -> None:
-    """Handle unsubscribe, pause, resume actions."""
-    handler_dict[user_id] = False
-    if not rss_dict.get(int(data[2])):
-        await query.answer(text="No subscriptions!", show_alert=True)
-        return
-    await query.answer()
-
-    buttons = ButtonMaker()
-    buttons.data_button("Back", f"rss back {user_id}")
-
-    action_buttons = {
-        "pause": "Pause AllMyFeeds",
-        "resume": "Resume AllMyFeeds",
-        "unsubscribe": "Unsub AllMyFeeds",
-    }
-    action_data = {
-        "pause": "uallpause",
-        "resume": "uallresume",
-        "unsubscribe": "uallunsub",
-    }
-    buttons.data_button(action_buttons[action], f"rss {action_data[action]} {user_id}")
-    buttons.data_button("Close", f"rss close {user_id}")
-
-    await edit_message(
-        query.message,
-        f"Send one or more rss titles separated by space to {action}.\nTimeout: 60 sec.",
-        buttons.build_menu(2),
-    )
-    await event_handler(
-        client, query, partial(rss_update, pre_event=query, state=action)
-    )
-
-
-async def _handle_edit(client, query, user_id: int, data: list[str]) -> None:
-    handler_dict[user_id] = False
-    if not rss_dict.get(int(data[2])):
-        await query.answer(text="No subscriptions!", show_alert=True)
-        return
-    await query.answer()
-    button = build_back_close_buttons(user_id).build_menu(2)
-    await edit_message(query.message, RSS_EDIT_HELP, button)
-    await event_handler(client, query, partial(rss_edit, pre_event=query))
-
-
-async def _handle_user_all(query, user_id: int, data: list[str], action: str) -> None:
-    """Handle uallpause, uallresume, uallunsub for single user."""
-    handler_dict[user_id] = False
-    target_user = int(data[2])
-
-    if not rss_dict.get(target_user):
-        await query.answer(text="No subscriptions!", show_alert=True)
-        return
-    await query.answer()
-
-    if action == "unsub":
-        async with rss_dict_lock:
-            del rss_dict[target_user]
-        await database.rss_delete(target_user)
-    else:
-        paused = action == "pause"
-        async with rss_dict_lock:
-            for info in rss_dict[target_user].values():
-                info["paused"] = paused
-        if action == "resume" and scheduler.state == 2:
-            scheduler.resume()
-        await database.rss_update(target_user)
-
-    await update_rss_menu(query)
-
-
-async def _handle_all(query, user_id: int, action: str) -> None:
-    """Handle allpause, allresume, allunsub for all users."""
-    if not rss_dict:
-        await query.answer(text="No subscriptions!", show_alert=True)
-        return
-    await query.answer()
-
-    if action == "unsub":
-        async with rss_dict_lock:
-            rss_dict.clear()
-        await database.trunc_table("rss")
-    elif action == "pause":
-        async with rss_dict_lock:
-            for user_feeds in rss_dict.values():
-                for feed in user_feeds.values():
-                    feed["paused"] = True
-        if scheduler.running:
-            scheduler.pause()
-        await database.rss_update_all()
-    elif action == "resume":
-        async with rss_dict_lock:
-            for user_feeds in rss_dict.values():
-                for feed in user_feeds.values():
-                    feed["paused"] = False
-        if scheduler.state == 2:
-            scheduler.resume()
-        elif not scheduler.running:
-            add_job()
-            scheduler.start()
-        await database.rss_update_all()
-
-    await update_rss_menu(query)
-
-
-async def _handle_deluser(client, query, user_id: int) -> None:
-    if not rss_dict:
-        await query.answer(text="No subscriptions!", show_alert=True)
-        return
-    await query.answer()
-    button = build_back_close_buttons(user_id).build_menu(2)
-    await edit_message(
-        query.message,
-        "Send one or more user_id separated by space to delete their resources.\nTimeout: 60 sec.",
-        button,
-    )
-    await event_handler(client, query, partial(rss_delete, pre_event=query))
-
-
-async def _handle_listall(query, data: list[str]) -> None:
-    if not rss_dict:
-        await query.answer(text="No subscriptions!", show_alert=True)
-        return
-    await query.answer()
-    await rss_list(query, int(data[3]), all_users=True)
-
-
-async def _handle_shutdown(query) -> None:
-    if not scheduler.running:
-        await query.answer(text="Already Stopped!", show_alert=True)
-        return
-    await query.answer()
-    scheduler.shutdown(wait=False)
-    await sleep(0.5)
-    await update_rss_menu(query)
-
-
-async def _handle_start(query) -> None:
-    if scheduler.running:
-        await query.answer(text="Already Running!", show_alert=True)
-        return
-    await query.answer()
-    add_job()
-    scheduler.start()
-    await update_rss_menu(query)
-
-
 @new_task
-async def rss_listener(client, query) -> None:
+async def rss_listener(client, query):
     user_id = query.from_user.id
+    message = query.message
     data = query.data.split()
-    action = data[1]
-
-    # Permission check
     if int(data[2]) != user_id and not await CustomFilters.sudo("", query):
         await query.answer(
             text="You don't have permission to use these buttons!", show_alert=True
         )
-        return
-
-    # Simple actions (handlers manage their own query.answer())
-    if action == "close":
-        await _handle_close(query, user_id)
-    elif action == "back":
-        await _handle_back(query, user_id)
-    elif action == "sub":
-        await _handle_sub(client, query, user_id)
-    elif action == "list":
-        await _handle_list(query, user_id, data)
-    elif action == "get":
-        await _handle_get(client, query, user_id, data)
-    elif action in ("unsubscribe", "pause", "resume"):
-        await _handle_feed_action(client, query, user_id, data, action)
-    elif action == "edit":
-        await _handle_edit(client, query, user_id, data)
-    elif action.startswith("uall"):
-        await _handle_user_all(
-            query, user_id, data, action[4:]
-        )  # Extract pause/resume/unsub
-    elif action.startswith("all"):
-        await _handle_all(query, user_id, action[3:])  # Extract pause/resume/unsub
-    elif action == "deluser":
-        await _handle_deluser(client, query, user_id)
-    elif action == "listall":
-        await _handle_listall(query, data)
-    elif action == "shutdown":
-        await _handle_shutdown(query)
-    elif action == "start":
-        await _handle_start(query)
-
-
-# ======================== RSS Monitor ========================
-
-
-async def _process_feed_entry(
-    entry: dict,
-    feed_count: int,
-    title: str,
-    data: dict,
-    user: int,
-    rss_chat_id: int | str | None,
-    rss_topic_id: int | str | None,
-) -> bool:
-    """Process a single feed entry. Returns True to continue, False to break."""
-    try:
-        await sleep(10)
-    except Exception:
-        raise RssShutdownException("Rss Monitor Stopped!")
-
-    try:
-        item_title = entry["title"]
-        url = get_entry_link(entry)
-
-        # Check if we've reached the last known item
-        if data["last_feed"] == url or data["last_title"] == item_title:
-            return False
-
-        size = get_entry_size(entry)
-    except IndexError:
-        LOGGER.warning(
-            f"Reached Max index no. {feed_count} for this feed: {title}. Maybe you need to use less RSS_DELAY to not miss some torrents"
-        )
-        return False
-
-    # Apply filters
-    if not check_filters(item_title, data):
-        return True
-
-    # Handle feed item
-    if command := data["command"]:
-        # Auto-download mode: start download directly
-        if size and Config.RSS_SIZE_LIMIT and Config.RSS_SIZE_LIMIT < size:
-            return True
-        await _start_rss_download(
-            url=url,
-            command=command,
-            user_id=user,
-            rss_chat_id=rss_chat_id,
-            rss_topic_id=rss_topic_id,
-            item_title=item_title,
-        )
-    else:
-        # Info-only mode: just post item details to RSS_CHAT
-        feed_msg = f"<b>Name: </b><code>{escape_html(item_title)}</code>"
-        feed_msg += f"\n\n<b>Link: </b><code>{url}</code>"
-        if size:
-            feed_msg += f"\n<b>Size: </b>{get_readable_file_size(size)}"
-        feed_msg += f"\n<b>Tag: </b><code>{data['tag']}</code> <code>{user}</code>"
-        await send_rss(feed_msg, rss_chat_id, rss_topic_id)
-    return True
-
-
-async def _process_feed(
-    user: int,
-    title: str,
-    data: dict,
-    rss_chat_id: int | str | None,
-    rss_topic_id: int | str | None,
-) -> bool:
-    """Process a single RSS feed. Returns True if feed was active (not paused)."""
-    if data["paused"]:
-        return False
-
-    html = await fetch_rss(data["link"])
-    rss_d = feed_parse(html)
-    if not rss_d.entries:
-        LOGGER.warning(
-            f"No entries found for > Feed Title: {title} - Feed Link: {data['link']}"
-        )
-        return True
-
-    entry0 = rss_d.entries[0]
-    last_link = get_entry_link(entry0)
-    last_title = entry0.get("title", "")
-
-    # No new items
-    if data["last_feed"] == last_link or data["last_title"] == last_title:
-        return True
-
-    # Process new entries
-    for feed_count, entry in enumerate(rss_d.entries):
-        should_continue = await _process_feed_entry(
-            entry, feed_count, title, data, user, rss_chat_id, rss_topic_id
-        )
-        if not should_continue:
-            break
-
-    # Update last seen
-    async with rss_dict_lock:
-        if user in rss_dict and rss_dict[user].get(title):
-            rss_dict[user][title].update(
-                {"last_feed": last_link, "last_title": last_title}
+    elif data[1] == "close":
+        await query.answer()
+        handler_dict[user_id] = False
+        await delete_message(message.reply_to_message)
+        await delete_message(message)
+    elif data[1] == "back":
+        await query.answer()
+        handler_dict[user_id] = False
+        await update_rss_menu(query)
+    elif data[1] == "sub":
+        await query.answer()
+        handler_dict[user_id] = False
+        buttons = ButtonMaker()
+        buttons.data_button("Back", f"rss back {user_id}")
+        buttons.data_button("Close", f"rss close {user_id}")
+        button = buttons.build_menu(2)
+        await edit_message(message, RSS_HELP_MESSAGE, button)
+        pfunc = partial(rss_sub, pre_event=query)
+        await event_handler(client, query, pfunc)
+    elif data[1] == "list":
+        handler_dict[user_id] = False
+        if len(rss_dict.get(int(data[2]), {})) == 0:
+            await query.answer(text="No subscriptions!", show_alert=True)
+        else:
+            await query.answer()
+            start = int(data[3])
+            await rss_list(query, start)
+    elif data[1] == "get":
+        handler_dict[user_id] = False
+        if len(rss_dict.get(int(data[2]), {})) == 0:
+            await query.answer(text="No subscriptions!", show_alert=True)
+        else:
+            await query.answer()
+            buttons = ButtonMaker()
+            buttons.data_button("Back", f"rss back {user_id}")
+            buttons.data_button("Close", f"rss close {user_id}")
+            button = buttons.build_menu(2)
+            await edit_message(
+                message,
+                "Send one title with value separated by space get last X items.\nTitle Value\nTimeout: 60 sec.",
+                button,
             )
+            pfunc = partial(rss_get, pre_event=query)
+            await event_handler(client, query, pfunc)
+    elif data[1] in ["unsubscribe", "pause", "resume"]:
+        handler_dict[user_id] = False
+        if len(rss_dict.get(int(data[2]), {})) == 0:
+            await query.answer(text="No subscriptions!", show_alert=True)
+        else:
+            await query.answer()
+            buttons = ButtonMaker()
+            buttons.data_button("Back", f"rss back {user_id}")
+            if data[1] == "pause":
+                buttons.data_button("Pause AllMyFeeds", f"rss uallpause {user_id}")
+            elif data[1] == "resume":
+                buttons.data_button("Resume AllMyFeeds", f"rss uallresume {user_id}")
+            elif data[1] == "unsubscribe":
+                buttons.data_button("Unsub AllMyFeeds", f"rss uallunsub {user_id}")
+            buttons.data_button("Close", f"rss close {user_id}")
+            button = buttons.build_menu(2)
+            await edit_message(
+                message,
+                f"Send one or more rss titles separated by space to {data[1]}.\nTimeout: 60 sec.",
+                button,
+            )
+            pfunc = partial(rss_update, pre_event=query, state=data[1])
+            await event_handler(client, query, pfunc)
+    elif data[1] == "edit":
+        handler_dict[user_id] = False
+        if len(rss_dict.get(int(data[2]), {})) == 0:
+            await query.answer(text="No subscriptions!", show_alert=True)
+        else:
+            await query.answer()
+            buttons = ButtonMaker()
+            buttons.data_button("Back", f"rss back {user_id}")
+            buttons.data_button("Close", f"rss close {user_id}")
+            button = buttons.build_menu(2)
+            msg = """Send one or more rss titles with new filters or command separated by new line.
+Examples:
+Title1 -c mirror -up remote:path/subdir -exf none -inf 1080 or 720 -stv true
+Title2 -c none -inf none -stv false
+Title3 -c mirror -rcf xxx -up xxx -z pswd -stv false
+Note: Only what you provide will be edited, the rest will be the same like example 2: exf will stay same as it is.
+Timeout: 60 sec. Argument -c for command and arguments
+            """
+            await edit_message(message, msg, button)
+            pfunc = partial(rss_edit, pre_event=query)
+            await event_handler(client, query, pfunc)
+    elif data[1].startswith("uall"):
+        handler_dict[user_id] = False
+        if len(rss_dict.get(int(data[2]), {})) == 0:
+            await query.answer(text="No subscriptions!", show_alert=True)
+            return
+        await query.answer()
+        if data[1].endswith("unsub"):
+            async with rss_dict_lock:
+                del rss_dict[int(data[2])]
+            await database.rss_delete(int(data[2]))
+            await update_rss_menu(query)
+        elif data[1].endswith("pause"):
+            async with rss_dict_lock:
+                for info in rss_dict[int(data[2])].values():
+                    info["paused"] = True
+            await database.rss_update(int(data[2]))
+        elif data[1].endswith("resume"):
+            async with rss_dict_lock:
+                for info in rss_dict[int(data[2])].values():
+                    info["paused"] = False
+            if scheduler.state == 2:
+                scheduler.resume()
+            await database.rss_update(int(data[2]))
+        await update_rss_menu(query)
+    elif data[1].startswith("all"):
+        if len(rss_dict) == 0:
+            await query.answer(text="No subscriptions!", show_alert=True)
+            return
+        await query.answer()
+        if data[1].endswith("unsub"):
+            async with rss_dict_lock:
+                rss_dict.clear()
+            await database.trunc_table("rss")
+            await update_rss_menu(query)
+        elif data[1].endswith("pause"):
+            async with rss_dict_lock:
+                for user_feeds in rss_dict.values():
+                    for feed in user_feeds.values():
+                        feed["paused"] = True
+            if scheduler.running:
+                scheduler.pause()
+            await database.rss_update_all()
+        elif data[1].endswith("resume"):
+            async with rss_dict_lock:
+                for user_feeds in rss_dict.values():
+                    for feed in user_feeds.values():
+                        feed["paused"] = False
+            if scheduler.state == 2:
+                scheduler.resume()
+            elif not scheduler.running:
+                add_job()
+                scheduler.start()
+                await update_rss_menu(query)
+            await database.rss_update_all()
+    elif data[1] == "deluser":
+        if len(rss_dict) == 0:
+            await query.answer(text="No subscriptions!", show_alert=True)
+        else:
+            await query.answer()
+            buttons = ButtonMaker()
+            buttons.data_button("Back", f"rss back {user_id}")
+            buttons.data_button("Close", f"rss close {user_id}")
+            button = buttons.build_menu(2)
+            msg = "Send one or more user_id separated by space to delete their resources.\nTimeout: 60 sec."
+            await edit_message(message, msg, button)
+            pfunc = partial(rss_delete, pre_event=query)
+            await event_handler(client, query, pfunc)
+    elif data[1] == "listall":
+        if not rss_dict:
+            await query.answer(text="No subscriptions!", show_alert=True)
+        else:
+            await query.answer()
+            start = int(data[3])
+            await rss_list(query, start, all_users=True)
+    elif data[1] == "shutdown":
+        if scheduler.running:
+            await query.answer()
+            scheduler.shutdown(wait=False)
+            await sleep(0.5)
+            await update_rss_menu(query)
+        else:
+            await query.answer(text="Already Stopped!", show_alert=True)
+    elif data[1] == "start":
+        if not scheduler.running:
+            await query.answer()
+            add_job()
+            scheduler.start()
+            await update_rss_menu(query)
+        else:
+            await query.answer(text="Already Running!", show_alert=True)
 
-    await database.rss_update(user)
-    LOGGER.info(f"Feed Name: {title}")
-    LOGGER.info(f"Last item: {last_link}")
-    return True
 
-
-async def rss_monitor() -> None:
+async def rss_monitor():
     chat = Config.RSS_CHAT
     if not chat:
-        LOGGER.warning("RSS_CHAT not configured! Shutting down rss scheduler...")
+        LOGGER.warning("RSS_CHAT not added! Shutting down rss scheduler...")
         scheduler.shutdown(wait=False)
         return
-
-    if not rss_dict:
+    if len(rss_dict) == 0:
         scheduler.pause()
         return
-
-    rss_chat_id, rss_topic_id = parse_chat_id(chat)
     all_paused = True
-
+    rss_topic_id = rss_chat_id = None
+    if isinstance(chat, int):
+        rss_chat_id = chat
+    elif "|" in chat:
+        rss_chat_id, rss_topic_id = list(
+            map(
+                lambda x: int(x) if x.lstrip("-").isdigit() else x,
+                chat.split("|", 1),
+            )
+        )
+    elif chat.lstrip("-").isdigit():
+        rss_chat_id = int(chat)
     for user, items in list(rss_dict.items()):
         for title, data in items.items():
             try:
-                if await _process_feed(user, title, data, rss_chat_id, rss_topic_id):
-                    all_paused = False
+                if data["paused"]:
+                    continue
+                tries = 0
+                while True:
+                    try:
+                        async with AsyncClient(
+                            headers=headers,
+                            follow_redirects=True,
+                            timeout=60,
+                            verify=False,
+                        ) as client:
+                            res = await client.get(data["link"])
+                        html = res.text
+                        break
+                    except:
+                        tries += 1
+                        if tries > 3:
+                            raise
+                        continue
+                rss_d = feed_parse(html)
+                if not rss_d.entries:
+                    LOGGER.warning(
+                        f"No entries found for > Feed Title: {title} - Feed Link: {data['link']}"
+                    )
+                    continue
+                entry0 = rss_d.entries[0]
+                links = entry0.get("links", [])
+                if len(links) > 1:
+                    last_link = links[1].get("href")
+                elif links:
+                    last_link = links[0].get("href")
+                else:
+                    last_link = entry0.get("link")
+                last_title = entry0.get("title")
+                all_paused = False
+                if data["last_feed"] == last_link or data["last_title"] == last_title:
+                    continue
+                feed_count = 0
+                while True:
+                    try:
+                        await sleep(10)
+                    except:
+                        raise RssShutdownException("Rss Monitor Stopped!")
+                    try:
+                        item_title = rss_d.entries[feed_count]["title"]
+                        try:
+                            url = rss_d.entries[feed_count]["links"][1]["href"]
+                        except IndexError:
+                            url = rss_d.entries[feed_count]["link"]
+                        if data["last_feed"] == url or data["last_title"] == item_title:
+                            break
+                        if rss_d.entries[feed_count].get("size"):
+                            size = int(rss_d.entries[feed_count]["size"])
+                        elif rss_d.entries[feed_count].get("summary"):
+                            summary = rss_d.entries[feed_count]["summary"]
+                            matches = size_regex.findall(summary)
+                            sizes = [match[0] for match in matches]
+                            size = get_size_bytes(sizes[0])
+                        else:
+                            size = 0
+                    except IndexError:
+                        LOGGER.warning(
+                            f"Reached Max index no. {feed_count} for this feed: {title}. Maybe you need to use less RSS_DELAY to not miss some torrents"
+                        )
+                        break
+                    parse = True
+                    for flist in data["inf"]:
+                        if (
+                            data.get("sensitive", False)
+                            and all(x.lower() not in item_title.lower() for x in flist)
+                        ) or (
+                            not data.get("sensitive", False)
+                            and all(x not in item_title for x in flist)
+                        ):
+                            parse = False
+                            feed_count += 1
+                            break
+                    if not parse:
+                        continue
+                    for flist in data["exf"]:
+                        if (
+                            data.get("sensitive", False)
+                            and any(x.lower() in item_title.lower() for x in flist)
+                        ) or (
+                            not data.get("sensitive", False)
+                            and any(x in item_title for x in flist)
+                        ):
+                            parse = False
+                            feed_count += 1
+                            break
+                    if not parse:
+                        continue
+                    if command := data["command"]:
+                        if (
+                            size
+                            and Config.RSS_SIZE_LIMIT
+                            and Config.RSS_SIZE_LIMIT < size
+                        ):
+                            feed_count += 1
+                            continue
+                        await _start_rss_download(
+                            url=url,
+                            command=command,
+                            user_id=user,
+                            rss_chat_id=rss_chat_id,
+                            rss_topic_id=rss_topic_id,
+                            item_title=item_title,
+                        )
+                    else:
+                        feed_msg = f"<b>Name: </b><code>{item_title.replace('>', '').replace('<', '')}</code>"
+                        feed_msg += f"\n\n<b>Link: </b><code>{url}</code>"
+                        if size:
+                            feed_msg += f"\n<b>Size: </b>{get_readable_file_size(size)}"
+                        feed_msg += f"\n<b>Tag: </b><code>{data['tag']}</code> <code>{user}</code>"
+                        await send_rss(feed_msg, rss_chat_id, rss_topic_id)
+                    feed_count += 1
+                async with rss_dict_lock:
+                    if user not in rss_dict or not rss_dict[user].get(title, False):
+                        continue
+                    rss_dict[user][title].update(
+                        {"last_feed": last_link, "last_title": last_title}
+                    )
+                await database.rss_update(user)
+                LOGGER.info(f"Feed Name: {title}")
+                LOGGER.info(f"Last item: {last_link}")
             except RssShutdownException as ex:
                 LOGGER.info(ex)
-                return
+                break
             except Exception as e:
                 LOGGER.error(f"{e} - Feed Name: {title} - Feed Link: {data['link']}")
-
+                continue
     if all_paused:
         scheduler.pause()
 
 
-# ======================== Scheduler Setup ========================
-
-
-def add_job() -> None:
+def add_job():
     scheduler.add_job(
         rss_monitor,
         trigger=IntervalTrigger(seconds=Config.RSS_DELAY),

--- a/bot/modules/rss.py
+++ b/bot/modules/rss.py
@@ -29,16 +29,135 @@ from ..helper.telegram_helper.message_utils import (
 
 rss_dict_lock = Lock()
 handler_dict = {}
-size_regex = compile(r"(\d+(\.\d+)?\s?(GB|MB|KB|GiB|MiB|KiB))", I)
+SIZE_REGEX = compile(r"(\d+(\.\d+)?\s?(GB|MB|KB|GiB|MiB|KiB))", I)
 
-headers = {
+HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36",
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
     "Accept-Language": "en-US,en;q=0.5",
 }
 
+RSS_EDIT_HELP = """Send one or more rss titles with new filters or command separated by new line.
+Examples:
+Title1 -c mirror -up remote:path/subdir -exf none -inf 1080 or 720 -stv true
+Title2 -c none -inf none -stv false
+Title3 -c mirror -rcf xxx -up xxx -z pswd -stv false
+Note: Only what you provide will be edited, the rest will be the same like example 2: exf will stay same as it is.
+Timeout: 60 sec. Argument -c for command and arguments"""
 
-async def rss_menu(event):
+
+# ======================== Helper Functions ========================
+
+
+async def fetch_rss(url: str, retries: int = 3) -> str | None:
+    """Fetch RSS feed with retries."""
+    for attempt in range(retries + 1):
+        try:
+            async with AsyncClient(
+                headers=HEADERS, follow_redirects=True, timeout=60, verify=False
+            ) as client:
+                res = await client.get(url)
+            return res.text
+        except Exception:
+            if attempt >= retries:
+                raise
+    return None
+
+
+def get_entry_link(entry: dict) -> str:
+    """Extract link from RSS entry."""
+    links = entry.get("links", [])
+    if len(links) > 1:
+        return links[1].get("href", "")
+    if links:
+        return links[0].get("href", "")
+    return entry.get("link", "")
+
+
+def get_entry_size(entry: dict) -> int:
+    """Extract size from RSS entry."""
+    if entry.get("size"):
+        return int(entry["size"])
+    if summary := entry.get("summary"):
+        if matches := SIZE_REGEX.findall(summary):
+            return get_size_bytes(matches[0][0])
+    return 0
+
+
+def parse_filters(filter_str: str | None) -> list[list[str]]:
+    """Parse filter string into list of filter groups."""
+    if not filter_str:
+        return []
+    return [x.split(" or ") for x in filter_str.split("|")]
+
+
+def check_filters(item_title: str, data: dict) -> bool:
+    """Check if item passes include/exclude filters. Returns True if item should be processed."""
+    sensitive = data.get("sensitive", False)
+
+    def matches(term: str, title: str) -> bool:
+        if sensitive:
+            return term.lower() in title.lower()
+        return term in title
+
+    # Check include filters - at least one term in each group must match
+    for flist in data["inf"]:
+        if all(not matches(term, item_title) for term in flist):
+            return False
+
+    # Check exclude filters - if any term matches, exclude
+    for flist in data["exf"]:
+        if any(matches(term, item_title) for term in flist):
+            return False
+
+    return True
+
+
+def parse_chat_id(chat: int | str) -> tuple[int | str | None, int | str | None]:
+    """Parse RSS_CHAT config into chat_id and topic_id."""
+    if isinstance(chat, int):
+        return chat, None
+    if "|" in chat:
+        parts = chat.split("|", 1)
+        chat_id = int(parts[0]) if parts[0].lstrip("-").isdigit() else parts[0]
+        topic_id = int(parts[1]) if parts[1].lstrip("-").isdigit() else parts[1]
+        return chat_id, topic_id
+    if chat.lstrip("-").isdigit():
+        return int(chat), None
+    return None, None
+
+
+def build_back_close_buttons(user_id: int) -> ButtonMaker:
+    """Create standard back/close button layout."""
+    buttons = ButtonMaker()
+    buttons.data_button("Back", f"rss back {user_id}")
+    buttons.data_button("Close", f"rss close {user_id}")
+    return buttons
+
+
+def format_feed_info(title: str, data: dict, show_user: bool = False) -> str:
+    """Format feed information for display."""
+    info = f"\n\n<b>Title:</b> <code>{title}</code>\n"
+    info += f"<b>Feed Url:</b> <code>{data['link']}</code>\n"
+    info += f"<b>Command:</b> <code>{data['command']}</code>\n"
+    info += f"<b>Inf:</b> <code>{data['inf']}</code>\n"
+    info += f"<b>Exf:</b> <code>{data['exf']}</code>\n"
+    info += f"<b>Sensitive:</b> <code>{data.get('sensitive', False)}</code>\n"
+    info += f"<b>Paused:</b> <code>{data['paused']}</code>\n"
+    if show_user:
+        info += f"<b>User:</b> {data['tag'].replace('@', '', 1)}"
+    return info
+
+
+def escape_html(text: str) -> str:
+    """Escape < and > for HTML display."""
+    return text.replace(">", "").replace("<", "")
+
+
+# ======================== Menu Functions ========================
+
+
+async def rss_menu(event) -> tuple[str, list]:
     user_id = event.from_user.id
     buttons = ButtonMaker()
     buttons.data_button("Subscribe", f"rss sub {user_id}")
@@ -48,227 +167,234 @@ async def rss_menu(event):
     buttons.data_button("Pause", f"rss pause {user_id}")
     buttons.data_button("Resume", f"rss resume {user_id}")
     buttons.data_button("Unsubscribe", f"rss unsubscribe {user_id}")
+
     if await CustomFilters.sudo("", event):
         buttons.data_button("All Subscriptions", f"rss listall {user_id} 0")
         buttons.data_button("Pause All", f"rss allpause {user_id}")
         buttons.data_button("Resume All", f"rss allresume {user_id}")
         buttons.data_button("Unsubscribe All", f"rss allunsub {user_id}")
         buttons.data_button("Delete User", f"rss deluser {user_id}")
-        if scheduler.running:
-            buttons.data_button("Shutdown Rss", f"rss shutdown {user_id}")
-        else:
-            buttons.data_button("Start Rss", f"rss start {user_id}")
+        btn_text = "Shutdown Rss" if scheduler.running else "Start Rss"
+        btn_data = "shutdown" if scheduler.running else "start"
+        buttons.data_button(btn_text, f"rss {btn_data} {user_id}")
+
     buttons.data_button("Close", f"rss close {user_id}")
-    button = buttons.build_menu(2)
-    msg = f"Rss Menu | Users: {len(rss_dict)} | Running: {scheduler.running}"
-    return msg, button
+    return (
+        f"Rss Menu | Users: {len(rss_dict)} | Running: {scheduler.running}",
+        buttons.build_menu(2),
+    )
 
 
-async def update_rss_menu(query):
+async def update_rss_menu(query) -> None:
     msg, button = await rss_menu(query)
     await edit_message(query.message, msg, button)
 
 
 @new_task
-async def get_rss_menu(_, message):
+async def get_rss_menu(_, message) -> None:
     msg, button = await rss_menu(message)
     await send_message(message, msg, button)
 
 
+# ======================== Subscription Functions ========================
+
+
+async def _process_subscription(
+    message, title: str, feed_link: str, args: list, tag: str, user_id: int
+) -> str | None:
+    """Process a single RSS subscription. Returns message string on success, None on failure."""
+    # Parse arguments
+    arg_base = {"-c": None, "-inf": None, "-exf": None, "-stv": None}
+    if len(args) > 2:
+        arg_parser(args[2:], arg_base)
+
+    cmd = arg_base["-c"]
+    inf = arg_base["-inf"]
+    exf = arg_base["-exf"]
+    stv = arg_base["-stv"]
+    stv = stv.lower() == "true" if stv is not None else False
+
+    inf_lists = parse_filters(inf)
+    exf_lists = parse_filters(exf)
+
+    try:
+        html = await fetch_rss(feed_link)
+        rss_d = feed_parse(html)
+
+        last_link = ""
+        last_title = ""
+        size = 0
+        feed_title = rss_d.feed.get("title", "Unknown")
+
+        if rss_d.entries:
+            entry = rss_d.entries[0]
+            last_title = entry["title"]
+            last_link = get_entry_link(entry)
+            size = get_entry_size(entry)
+
+        # Build response message
+        msg = "<b>Subscribed!</b>"
+        msg += f"\n<b>Title: </b><code>{title}</code>\n<b>Feed Url: </b>{feed_link}"
+
+        if rss_d.entries:
+            msg += f"\n<b>latest record for </b>{feed_title}:"
+            msg += f"\nName: <code>{escape_html(last_title)}</code>"
+            msg += f"\n<b>Link: </b><code>{last_link}</code>"
+            if size:
+                msg += f"\nSize: {get_readable_file_size(size)}"
+        else:
+            msg += "\n<b>Note:</b> Feed is currently empty, will be monitored for new items."
+
+        msg += f"\n<b>Command: </b><code>{cmd}</code>"
+        msg += f"\n<b>Filters:-</b>\ninf: <code>{inf}</code>\nexf: <code>{exf}</code>\n<b>sensitive: </b>{stv}"
+
+        # Store subscription
+        feed_data = {
+            "link": feed_link,
+            "last_feed": last_link,
+            "last_title": last_title,
+            "inf": inf_lists,
+            "exf": exf_lists,
+            "paused": False,
+            "command": cmd,
+            "sensitive": stv,
+            "tag": tag,
+        }
+
+        async with rss_dict_lock:
+            if user_id not in rss_dict:
+                rss_dict[user_id] = {}
+            rss_dict[user_id][title] = feed_data
+
+        LOGGER.info(
+            f"Rss Feed Added: id: {user_id} - title: {title} - link: {feed_link} - c: {cmd} - inf: {inf} - exf: {exf} - stv: {stv}"
+        )
+        return msg
+
+    except (IndexError, AttributeError) as e:
+        await send_message(
+            message,
+            f"The link: {feed_link} doesn't seem to be a RSS feed or it's region-blocked!\nError: {e}",
+        )
+    except Exception as e:
+        await send_message(message, str(e))
+    return None
+
+
 @new_task
-async def rss_sub(_, message, pre_event):
+async def rss_sub(_, message, pre_event) -> None:
     user_id = message.from_user.id
     handler_dict[user_id] = False
-    if username := message.from_user.username:
-        tag = f"@{username}"
-    else:
-        tag = message.from_user.mention
-    msg = ""
-    items = message.text.split("\n")
-    for index, item in enumerate(items, start=1):
+    tag = (
+        f"@{message.from_user.username}"
+        if message.from_user.username
+        else message.from_user.mention
+    )
+
+    result_msg = ""
+    for index, item in enumerate(message.text.split("\n"), start=1):
         args = item.split()
+
         if len(args) < 2:
             await send_message(
                 message,
                 f"{item}. Wrong Input format. Read help message before adding new subscription!",
             )
             continue
+
         title = args[0].strip()
-        if (user_feeds := rss_dict.get(user_id, False)) and title in user_feeds:
+        if (user_feeds := rss_dict.get(user_id)) and title in user_feeds:
             await send_message(
                 message, f"This title {title} already subscribed! Choose another title!"
             )
             continue
+
         feed_link = args[1].strip()
         if feed_link.startswith(("-inf", "-exf", "-c")):
             await send_message(
-                message,
-                f"Wrong input in line {index}! Add Title! Read the example!",
+                message, f"Wrong input in line {index}! Add Title! Read the example!"
             )
             continue
-        inf_lists = []
-        exf_lists = []
-        if len(args) > 2:
-            arg_base = {"-c": None, "-inf": None, "-exf": None, "-stv": None}
-            arg_parser(args[2:], arg_base)
-            cmd = arg_base["-c"]
-            inf = arg_base["-inf"]
-            exf = arg_base["-exf"]
-            stv = arg_base["-stv"]
-            if stv is not None:
-                stv = stv.lower() == "true"
-            if inf is not None:
-                filters_list = inf.split("|")
-                for x in filters_list:
-                    y = x.split(" or ")
-                    inf_lists.append(y)
-            if exf is not None:
-                filters_list = exf.split("|")
-                for x in filters_list:
-                    y = x.split(" or ")
-                    exf_lists.append(y)
-        else:
-            inf = None
-            exf = None
-            cmd = None
-            stv = False
-        try:
-            async with AsyncClient(
-                headers=headers, follow_redirects=True, timeout=60, verify=False
-            ) as client:
-                res = await client.get(feed_link)
-            html = res.text
-            rss_d = feed_parse(html)
-            last_link = ""
-            last_title = ""
-            size = 0
-            feed_title = rss_d.feed.get("title", "Unknown")
-            if rss_d.entries:
-                last_title = rss_d.entries[0]["title"]
-                if rss_d.entries[0].get("size"):
-                    size = int(rss_d.entries[0]["size"])
-                elif rss_d.entries[0].get("summary"):
-                    summary = rss_d.entries[0]["summary"]
-                    matches = size_regex.findall(summary)
-                    sizes = [match[0] for match in matches]
-                    size = get_size_bytes(sizes[0])
-                try:
-                    last_link = rss_d.entries[0]["links"][1]["href"]
-                except IndexError:
-                    last_link = rss_d.entries[0]["link"]
-            msg += "<b>Subscribed!</b>"
-            msg += f"\n<b>Title: </b><code>{title}</code>\n<b>Feed Url: </b>{feed_link}"
-            if rss_d.entries:
-                msg += f"\n<b>latest record for </b>{feed_title}:"
-                msg += f"\nName: <code>{last_title.replace('>', '').replace('<', '')}</code>"
-                msg += f"\n<b>Link: </b><code>{last_link}</code>"
-                if size:
-                    msg += f"\nSize: {get_readable_file_size(size)}"
-            else:
-                msg += f"\n<b>Note:</b> Feed is currently empty, will be monitored for new items."
-            msg += f"\n<b>Command: </b><code>{cmd}</code>"
-            msg += f"\n<b>Filters:-</b>\ninf: <code>{inf}</code>\nexf: <code>{exf}</code>\n<b>sensitive: </b>{stv}"
-            async with rss_dict_lock:
-                if rss_dict.get(user_id, False):
-                    rss_dict[user_id][title] = {
-                        "link": feed_link,
-                        "last_feed": last_link,
-                        "last_title": last_title,
-                        "inf": inf_lists,
-                        "exf": exf_lists,
-                        "paused": False,
-                        "command": cmd,
-                        "sensitive": stv,
-                        "tag": tag,
-                    }
-                else:
-                    rss_dict[user_id] = {
-                        title: {
-                            "link": feed_link,
-                            "last_feed": last_link,
-                            "last_title": last_title,
-                            "inf": inf_lists,
-                            "exf": exf_lists,
-                            "paused": False,
-                            "command": cmd,
-                            "sensitive": stv,
-                            "tag": tag,
-                        }
-                    }
-            LOGGER.info(
-                f"Rss Feed Added: id: {user_id} - title: {title} - link: {feed_link} - c: {cmd} - inf: {inf} - exf: {exf} - stv: {stv}"
-            )
-        except (IndexError, AttributeError) as e:
-            emsg = f"The link: {feed_link} doesn't seem to be a RSS feed or it's region-blocked!"
-            await send_message(message, emsg + "\nError: " + str(e))
-        except Exception as e:
-            await send_message(message, str(e))
-    if msg:
+
+        if sub_msg := await _process_subscription(
+            message, title, feed_link, args, tag, user_id
+        ):
+            result_msg += sub_msg
+
+    if result_msg:
         await database.rss_update(user_id)
-        await send_message(message, msg)
+        await send_message(message, result_msg)
         is_sudo = await CustomFilters.sudo("", message)
         if scheduler.state == 2:
             scheduler.resume()
         elif is_sudo and not scheduler.running:
             add_job()
             scheduler.start()
+
     await update_rss_menu(pre_event)
 
 
-async def get_user_id(title):
+# ======================== Update Functions ========================
+
+
+async def get_user_id(title: str) -> tuple[bool, int | bool]:
     async with rss_dict_lock:
         return next(
-            (
-                (True, user_id)
-                for user_id, feed in rss_dict.items()
-                if feed["title"] == title
-            ),
+            ((True, user_id) for user_id, feeds in rss_dict.items() if title in feeds),
             (False, False),
         )
 
 
 @new_task
-async def rss_update(_, message, pre_event, state):
+async def rss_update(_, message, pre_event, state: str) -> None:
     user_id = message.from_user.id
     handler_dict[user_id] = False
-    titles = message.text.split()
     is_sudo = await CustomFilters.sudo("", message)
     updated = []
-    for title in titles:
+
+    for title in message.text.split():
         title = title.strip()
-        if not (res := rss_dict[user_id].get(title, False)):
+        current_user_id = user_id
+
+        if not rss_dict.get(current_user_id, {}).get(title):
             if is_sudo:
-                res, user_id = await get_user_id(title)
-            if not res:
-                user_id = message.from_user.id
+                found, current_user_id = await get_user_id(title)
+                if not found:
+                    await send_message(message, f"{title} not found!")
+                    continue
+            else:
                 await send_message(message, f"{title} not found!")
                 continue
-        istate = rss_dict[user_id][title].get("paused", False)
-        if istate and state == "pause" or not istate and state == "resume":
+
+        is_paused = rss_dict[current_user_id][title].get("paused", False)
+        if (is_paused and state == "pause") or (not is_paused and state == "resume"):
             await send_message(message, f"{title} already {state}d!")
             continue
+
         async with rss_dict_lock:
             updated.append(title)
             if state == "unsubscribe":
-                del rss_dict[user_id][title]
-            elif state == "pause":
-                rss_dict[user_id][title]["paused"] = True
-            elif state == "resume":
-                rss_dict[user_id][title]["paused"] = False
+                del rss_dict[current_user_id][title]
+            else:
+                rss_dict[current_user_id][title]["paused"] = state == "pause"
+
         if state == "resume":
             if scheduler.state == 2:
                 scheduler.resume()
             elif is_sudo and not scheduler.running:
                 add_job()
                 scheduler.start()
-        if is_sudo and Config.DATABASE_URL and user_id != message.from_user.id:
-            await database.rss_update(user_id)
-        if not rss_dict[user_id]:
+
+        if is_sudo and Config.DATABASE_URL and current_user_id != user_id:
+            await database.rss_update(current_user_id)
+
+        if not rss_dict.get(current_user_id):
             async with rss_dict_lock:
-                del rss_dict[user_id]
-            await database.rss_delete(user_id)
+                del rss_dict[current_user_id]
+            await database.rss_delete(current_user_id)
             if not rss_dict:
                 await database.trunc_table("rss")
+
     if updated:
         LOGGER.info(f"Rss link with Title(s): {updated} has been {state}d!")
         await send_message(
@@ -277,184 +403,185 @@ async def rss_update(_, message, pre_event, state):
         )
         if rss_dict.get(user_id):
             await database.rss_update(user_id)
+
     await update_rss_menu(pre_event)
 
 
-async def rss_list(query, start, all_users=False):
+# ======================== List Functions ========================
+
+
+async def rss_list(query, start: int, all_users: bool = False) -> None:
     user_id = query.from_user.id
-    buttons = ButtonMaker()
-    if all_users:
-        list_feed = f"<b>All subscriptions | Page: {int(start / 5)} </b>"
-        async with rss_dict_lock:
-            keysCount = sum(len(v.keys()) for v in rss_dict.values())
-            index = 0
+    buttons = build_back_close_buttons(user_id)
+    page = start // 5
+
+    async with rss_dict_lock:
+        if all_users:
+            list_feed = f"<b>All subscriptions | Page: {page} </b>"
+            keys_count = sum(len(v) for v in rss_dict.values())
+            count = 0
             for titles in rss_dict.values():
-                for index, (title, data) in enumerate(
-                    list(titles.items())[start : 5 + start]
-                ):
-                    list_feed += f"\n\n<b>Title:</b> <code>{title}</code>\n"
-                    list_feed += f"<b>Feed Url:</b> <code>{data['link']}</code>\n"
-                    list_feed += f"<b>Command:</b> <code>{data['command']}</code>\n"
-                    list_feed += f"<b>Inf:</b> <code>{data['inf']}</code>\n"
-                    list_feed += f"<b>Exf:</b> <code>{data['exf']}</code>\n"
-                    list_feed += f"<b>Sensitive:</b> <code>{data.get('sensitive', False)}</code>\n"
-                    list_feed += f"<b>Paused:</b> <code>{data['paused']}</code>\n"
-                    list_feed += f"<b>User:</b> {data['tag'].replace('@', '', 1)}"
-                    index += 1
-                    if index == 5:
+                for title, data in list(titles.items())[start : start + 5]:
+                    list_feed += format_feed_info(title, data, show_user=True)
+                    count += 1
+                    if count >= 5:
                         break
-    else:
-        list_feed = f"<b>Your subscriptions | Page: {int(start / 5)} </b>"
-        async with rss_dict_lock:
-            keysCount = len(rss_dict.get(user_id, {}).keys())
-            for title, data in list(rss_dict[user_id].items())[start : 5 + start]:
-                list_feed += f"\n\n<b>Title:</b> <code>{title}</code>\n<b>Feed Url: </b><code>{data['link']}</code>\n"
-                list_feed += f"<b>Command:</b> <code>{data['command']}</code>\n"
-                list_feed += f"<b>Inf:</b> <code>{data['inf']}</code>\n"
-                list_feed += f"<b>Exf:</b> <code>{data['exf']}</code>\n"
-                list_feed += (
-                    f"<b>Sensitive:</b> <code>{data.get('sensitive', False)}</code>\n"
-                )
-                list_feed += f"<b>Paused:</b> <code>{data['paused']}</code>\n"
-    buttons.data_button("Back", f"rss back {user_id}")
-    buttons.data_button("Close", f"rss close {user_id}")
-    if keysCount > 5:
-        for x in range(0, keysCount, 5):
+                if count >= 5:
+                    break
+        else:
+            list_feed = f"<b>Your subscriptions | Page: {page} </b>"
+            user_feeds = rss_dict.get(user_id, {})
+            keys_count = len(user_feeds)
+            for title, data in list(user_feeds.items())[start : start + 5]:
+                list_feed += format_feed_info(title, data, show_user=False)
+
+    if keys_count > 5:
+        for x in range(0, keys_count, 5):
             buttons.data_button(
-                f"{int(x / 5)}", f"rss list {user_id} {x}", position="footer"
+                f"{x // 5}", f"rss list {user_id} {x}", position="footer"
             )
+
     button = buttons.build_menu(2)
-    if query.message.text.html == list_feed:
-        return
-    await edit_message(query.message, list_feed, button)
+    if query.message.text.html != list_feed:
+        await edit_message(query.message, list_feed, button)
+
+
+# ======================== Get/Edit Functions ========================
 
 
 @new_task
-async def rss_get(_, message, pre_event):
+async def rss_get(_, message, pre_event) -> None:
     user_id = message.from_user.id
     handler_dict[user_id] = False
     args = message.text.split()
+
     if len(args) < 2:
         await send_message(
             message,
-            f"{args}. Wrong Input format. You should add number of the items you want to get. Read help message before adding new subscription!",
+            f"{args}. Wrong Input format. You should add number of the items you want to get.",
         )
         await update_rss_menu(pre_event)
         return
+
     try:
-        title = args[0]
-        count = int(args[1])
-        data = rss_dict[user_id].get(title, False)
-        if data and count > 0:
-            try:
-                msg = await send_message(
-                    message, f"Getting the last <b>{count}</b> item(s) from {title}"
-                )
-                async with AsyncClient(
-                    headers=headers, follow_redirects=True, timeout=60, verify=False
-                ) as client:
-                    res = await client.get(data["link"])
-                html = res.text
-                rss_d = feed_parse(html)
-                item_info = ""
-                for item_num in range(count):
-                    try:
-                        link = rss_d.entries[item_num]["links"][1]["href"]
-                    except IndexError:
-                        link = rss_d.entries[item_num]["link"]
-                    item_info += f"<b>Name: </b><code>{rss_d.entries[item_num]['title'].replace('>', '').replace('<', '')}</code>\n"
-                    item_info += f"<b>Link: </b><code>{link}</code>\n\n"
-                item_info_ecd = item_info.encode()
-                if len(item_info_ecd) > 4000:
-                    with BytesIO(item_info_ecd) as out_file:
-                        out_file.name = f"rssGet {title} items_no. {count}.txt"
-                        await send_file(message, out_file)
-                    await delete_message(msg)
-                else:
-                    await edit_message(msg, item_info)
-            except IndexError as e:
-                LOGGER.error(str(e))
-                await edit_message(
-                    msg, "Parse depth exceeded. Try again with a lower value."
-                )
-            except Exception as e:
-                LOGGER.error(str(e))
-                await edit_message(msg, str(e))
-        else:
+        title, count = args[0], int(args[1])
+        data = rss_dict.get(user_id, {}).get(title)
+
+        if not data or count <= 0:
             await send_message(message, "Enter a valid title. Title not found!")
+            await update_rss_menu(pre_event)
+            return
+
+        msg = await send_message(
+            message, f"Getting the last <b>{count}</b> item(s) from {title}"
+        )
+
+        try:
+            html = await fetch_rss(data["link"])
+            rss_d = feed_parse(html)
+
+            item_info = ""
+            for i in range(min(count, len(rss_d.entries))):
+                entry = rss_d.entries[i]
+                link = get_entry_link(entry)
+                item_info += (
+                    f"<b>Name: </b><code>{escape_html(entry['title'])}</code>\n"
+                )
+                item_info += f"<b>Link: </b><code>{link}</code>\n\n"
+
+            if len(item_info.encode()) > 4000:
+                with BytesIO(item_info.encode()) as out_file:
+                    out_file.name = f"rssGet {title} items_no. {count}.txt"
+                    await send_file(message, out_file)
+                await delete_message(msg)
+            else:
+                await edit_message(msg, item_info)
+
+        except IndexError:
+            LOGGER.error("Parse depth exceeded")
+            await edit_message(
+                msg, "Parse depth exceeded. Try again with a lower value."
+            )
+        except Exception as e:
+            LOGGER.error(str(e))
+            await edit_message(msg, str(e))
+
     except Exception as e:
         LOGGER.error(str(e))
         await send_message(message, f"Enter a valid value!. {e}")
+
     await update_rss_menu(pre_event)
 
 
 @new_task
-async def rss_edit(_, message, pre_event):
+async def rss_edit(_, message, pre_event) -> None:
     user_id = message.from_user.id
     handler_dict[user_id] = False
-    items = message.text.split("\n")
     updated = False
-    for item in items:
+
+    for item in message.text.split("\n"):
         args = item.split()
-        title = args[0].strip()
         if len(args) < 2:
             await send_message(
                 message,
                 f"{item}. Wrong Input format. Read help message before editing!",
             )
             continue
-        elif not rss_dict[user_id].get(title, False):
+
+        title = args[0].strip()
+        if not rss_dict.get(user_id, {}).get(title):
             await send_message(message, "Enter a valid title. Title not found!")
             continue
+
         updated = True
-        inf_lists = []
-        exf_lists = []
         arg_base = {"-c": None, "-inf": None, "-exf": None, "-stv": None}
         arg_parser(args[1:], arg_base)
-        cmd = arg_base["-c"]
-        inf = arg_base["-inf"]
-        exf = arg_base["-exf"]
-        stv = arg_base["-stv"]
+
         async with rss_dict_lock:
-            if stv is not None:
-                stv = stv.lower() == "true"
-                rss_dict[user_id][title]["sensitive"] = stv
-            if cmd is not None:
-                if cmd.lower() == "none":
-                    cmd = None
-                rss_dict[user_id][title]["command"] = cmd
-            if inf is not None:
-                if inf.lower() != "none":
-                    filters_list = inf.split("|")
-                    for x in filters_list:
-                        y = x.split(" or ")
-                        inf_lists.append(y)
-                rss_dict[user_id][title]["inf"] = inf_lists
-            if exf is not None:
-                if exf.lower() != "none":
-                    filters_list = exf.split("|")
-                    for x in filters_list:
-                        y = x.split(" or ")
-                        exf_lists.append(y)
-                rss_dict[user_id][title]["exf"] = exf_lists
+            feed = rss_dict[user_id][title]
+
+            if arg_base["-stv"] is not None:
+                feed["sensitive"] = arg_base["-stv"].lower() == "true"
+
+            if arg_base["-c"] is not None:
+                feed["command"] = (
+                    None if arg_base["-c"].lower() == "none" else arg_base["-c"]
+                )
+
+            if arg_base["-inf"] is not None:
+                feed["inf"] = (
+                    []
+                    if arg_base["-inf"].lower() == "none"
+                    else parse_filters(arg_base["-inf"])
+                )
+
+            if arg_base["-exf"] is not None:
+                feed["exf"] = (
+                    []
+                    if arg_base["-exf"].lower() == "none"
+                    else parse_filters(arg_base["-exf"])
+                )
+
     if updated:
         await database.rss_update(user_id)
     await update_rss_menu(pre_event)
 
 
 @new_task
-async def rss_delete(_, message, pre_event):
+async def rss_delete(_, message, pre_event) -> None:
     handler_dict[message.from_user.id] = False
-    users = message.text.split()
-    for user in users:
-        user = int(user)
+    for user in message.text.split():
+        user_id = int(user)
         async with rss_dict_lock:
-            del rss_dict[user]
-        await database.rss_delete(user)
+            del rss_dict[user_id]
+        await database.rss_delete(user_id)
     await update_rss_menu(pre_event)
 
 
-async def event_handler(client, query, pfunc):
+# ======================== Event Handler ========================
+
+
+async def event_handler(client, query, pfunc) -> None:
     user_id = query.from_user.id
     handler_dict[user_id] = True
     start_time = time()
@@ -466,363 +593,395 @@ async def event_handler(client, query, pfunc):
         )
 
     handler = client.add_handler(MessageHandler(pfunc, create(event_filter)), group=-1)
+
     while handler_dict[user_id]:
         await sleep(0.5)
         if time() - start_time > 60:
             handler_dict[user_id] = False
             await update_rss_menu(query)
+
     client.remove_handler(*handler)
 
 
+# ======================== Listener Handlers ========================
+
+
+async def _handle_close(query, user_id: int) -> None:
+    await query.answer()
+    handler_dict[user_id] = False
+    await delete_message(query.message.reply_to_message)
+    await delete_message(query.message)
+
+
+async def _handle_back(query, user_id: int) -> None:
+    await query.answer()
+    handler_dict[user_id] = False
+    await update_rss_menu(query)
+
+
+async def _handle_sub(client, query, user_id: int) -> None:
+    await query.answer()
+    handler_dict[user_id] = False
+    button = build_back_close_buttons(user_id).build_menu(2)
+    await edit_message(query.message, RSS_HELP_MESSAGE, button)
+    await event_handler(client, query, partial(rss_sub, pre_event=query))
+
+
+async def _handle_list(query, user_id: int, data: list[str]) -> None:
+    handler_dict[user_id] = False
+    if not rss_dict.get(int(data[2])):
+        await query.answer(text="No subscriptions!", show_alert=True)
+        return
+    await query.answer()
+    await rss_list(query, int(data[3]))
+
+
+async def _handle_get(client, query, user_id: int, data: list[str]) -> None:
+    handler_dict[user_id] = False
+    if not rss_dict.get(int(data[2])):
+        await query.answer(text="No subscriptions!", show_alert=True)
+        return
+    await query.answer()
+    button = build_back_close_buttons(user_id).build_menu(2)
+    await edit_message(
+        query.message,
+        "Send one title with value separated by space get last X items.\nTitle Value\nTimeout: 60 sec.",
+        button,
+    )
+    await event_handler(client, query, partial(rss_get, pre_event=query))
+
+
+async def _handle_feed_action(
+    client, query, user_id: int, data: list[str], action: str
+) -> None:
+    """Handle unsubscribe, pause, resume actions."""
+    handler_dict[user_id] = False
+    if not rss_dict.get(int(data[2])):
+        await query.answer(text="No subscriptions!", show_alert=True)
+        return
+    await query.answer()
+
+    buttons = ButtonMaker()
+    buttons.data_button("Back", f"rss back {user_id}")
+
+    action_buttons = {
+        "pause": "Pause AllMyFeeds",
+        "resume": "Resume AllMyFeeds",
+        "unsubscribe": "Unsub AllMyFeeds",
+    }
+    action_data = {
+        "pause": "uallpause",
+        "resume": "uallresume",
+        "unsubscribe": "uallunsub",
+    }
+    buttons.data_button(action_buttons[action], f"rss {action_data[action]} {user_id}")
+    buttons.data_button("Close", f"rss close {user_id}")
+
+    await edit_message(
+        query.message,
+        f"Send one or more rss titles separated by space to {action}.\nTimeout: 60 sec.",
+        buttons.build_menu(2),
+    )
+    await event_handler(
+        client, query, partial(rss_update, pre_event=query, state=action)
+    )
+
+
+async def _handle_edit(client, query, user_id: int, data: list[str]) -> None:
+    handler_dict[user_id] = False
+    if not rss_dict.get(int(data[2])):
+        await query.answer(text="No subscriptions!", show_alert=True)
+        return
+    await query.answer()
+    button = build_back_close_buttons(user_id).build_menu(2)
+    await edit_message(query.message, RSS_EDIT_HELP, button)
+    await event_handler(client, query, partial(rss_edit, pre_event=query))
+
+
+async def _handle_user_all(query, user_id: int, data: list[str], action: str) -> None:
+    """Handle uallpause, uallresume, uallunsub for single user."""
+    handler_dict[user_id] = False
+    target_user = int(data[2])
+
+    if not rss_dict.get(target_user):
+        await query.answer(text="No subscriptions!", show_alert=True)
+        return
+    await query.answer()
+
+    if action == "unsub":
+        async with rss_dict_lock:
+            del rss_dict[target_user]
+        await database.rss_delete(target_user)
+    else:
+        paused = action == "pause"
+        async with rss_dict_lock:
+            for info in rss_dict[target_user].values():
+                info["paused"] = paused
+        if action == "resume" and scheduler.state == 2:
+            scheduler.resume()
+        await database.rss_update(target_user)
+
+    await update_rss_menu(query)
+
+
+async def _handle_all(query, user_id: int, action: str) -> None:
+    """Handle allpause, allresume, allunsub for all users."""
+    if not rss_dict:
+        await query.answer(text="No subscriptions!", show_alert=True)
+        return
+    await query.answer()
+
+    if action == "unsub":
+        async with rss_dict_lock:
+            rss_dict.clear()
+        await database.trunc_table("rss")
+    elif action == "pause":
+        async with rss_dict_lock:
+            for user_feeds in rss_dict.values():
+                for feed in user_feeds.values():
+                    feed["paused"] = True
+        if scheduler.running:
+            scheduler.pause()
+        await database.rss_update_all()
+    elif action == "resume":
+        async with rss_dict_lock:
+            for user_feeds in rss_dict.values():
+                for feed in user_feeds.values():
+                    feed["paused"] = False
+        if scheduler.state == 2:
+            scheduler.resume()
+        elif not scheduler.running:
+            add_job()
+            scheduler.start()
+        await database.rss_update_all()
+
+    await update_rss_menu(query)
+
+
+async def _handle_deluser(client, query, user_id: int) -> None:
+    if not rss_dict:
+        await query.answer(text="No subscriptions!", show_alert=True)
+        return
+    await query.answer()
+    button = build_back_close_buttons(user_id).build_menu(2)
+    await edit_message(
+        query.message,
+        "Send one or more user_id separated by space to delete their resources.\nTimeout: 60 sec.",
+        button,
+    )
+    await event_handler(client, query, partial(rss_delete, pre_event=query))
+
+
+async def _handle_listall(query, data: list[str]) -> None:
+    if not rss_dict:
+        await query.answer(text="No subscriptions!", show_alert=True)
+        return
+    await query.answer()
+    await rss_list(query, int(data[3]), all_users=True)
+
+
+async def _handle_shutdown(query) -> None:
+    if not scheduler.running:
+        await query.answer(text="Already Stopped!", show_alert=True)
+        return
+    await query.answer()
+    scheduler.shutdown(wait=False)
+    await sleep(0.5)
+    await update_rss_menu(query)
+
+
+async def _handle_start(query) -> None:
+    if scheduler.running:
+        await query.answer(text="Already Running!", show_alert=True)
+        return
+    await query.answer()
+    add_job()
+    scheduler.start()
+    await update_rss_menu(query)
+
+
 @new_task
-async def rss_listener(client, query):
+async def rss_listener(client, query) -> None:
     user_id = query.from_user.id
-    message = query.message
     data = query.data.split()
+    action = data[1]
+
+    # Permission check
     if int(data[2]) != user_id and not await CustomFilters.sudo("", query):
         await query.answer(
             text="You don't have permission to use these buttons!", show_alert=True
         )
-    elif data[1] == "close":
-        await query.answer()
-        handler_dict[user_id] = False
-        await delete_message(message.reply_to_message)
-        await delete_message(message)
-    elif data[1] == "back":
-        await query.answer()
-        handler_dict[user_id] = False
-        await update_rss_menu(query)
-    elif data[1] == "sub":
-        await query.answer()
-        handler_dict[user_id] = False
-        buttons = ButtonMaker()
-        buttons.data_button("Back", f"rss back {user_id}")
-        buttons.data_button("Close", f"rss close {user_id}")
-        button = buttons.build_menu(2)
-        await edit_message(message, RSS_HELP_MESSAGE, button)
-        pfunc = partial(rss_sub, pre_event=query)
-        await event_handler(client, query, pfunc)
-    elif data[1] == "list":
-        handler_dict[user_id] = False
-        if len(rss_dict.get(int(data[2]), {})) == 0:
-            await query.answer(text="No subscriptions!", show_alert=True)
-        else:
-            await query.answer()
-            start = int(data[3])
-            await rss_list(query, start)
-    elif data[1] == "get":
-        handler_dict[user_id] = False
-        if len(rss_dict.get(int(data[2]), {})) == 0:
-            await query.answer(text="No subscriptions!", show_alert=True)
-        else:
-            await query.answer()
-            buttons = ButtonMaker()
-            buttons.data_button("Back", f"rss back {user_id}")
-            buttons.data_button("Close", f"rss close {user_id}")
-            button = buttons.build_menu(2)
-            await edit_message(
-                message,
-                "Send one title with value separated by space get last X items.\nTitle Value\nTimeout: 60 sec.",
-                button,
-            )
-            pfunc = partial(rss_get, pre_event=query)
-            await event_handler(client, query, pfunc)
-    elif data[1] in ["unsubscribe", "pause", "resume"]:
-        handler_dict[user_id] = False
-        if len(rss_dict.get(int(data[2]), {})) == 0:
-            await query.answer(text="No subscriptions!", show_alert=True)
-        else:
-            await query.answer()
-            buttons = ButtonMaker()
-            buttons.data_button("Back", f"rss back {user_id}")
-            if data[1] == "pause":
-                buttons.data_button("Pause AllMyFeeds", f"rss uallpause {user_id}")
-            elif data[1] == "resume":
-                buttons.data_button("Resume AllMyFeeds", f"rss uallresume {user_id}")
-            elif data[1] == "unsubscribe":
-                buttons.data_button("Unsub AllMyFeeds", f"rss uallunsub {user_id}")
-            buttons.data_button("Close", f"rss close {user_id}")
-            button = buttons.build_menu(2)
-            await edit_message(
-                message,
-                f"Send one or more rss titles separated by space to {data[1]}.\nTimeout: 60 sec.",
-                button,
-            )
-            pfunc = partial(rss_update, pre_event=query, state=data[1])
-            await event_handler(client, query, pfunc)
-    elif data[1] == "edit":
-        handler_dict[user_id] = False
-        if len(rss_dict.get(int(data[2]), {})) == 0:
-            await query.answer(text="No subscriptions!", show_alert=True)
-        else:
-            await query.answer()
-            buttons = ButtonMaker()
-            buttons.data_button("Back", f"rss back {user_id}")
-            buttons.data_button("Close", f"rss close {user_id}")
-            button = buttons.build_menu(2)
-            msg = """Send one or more rss titles with new filters or command separated by new line.
-Examples:
-Title1 -c mirror -up remote:path/subdir -exf none -inf 1080 or 720 -stv true
-Title2 -c none -inf none -stv false
-Title3 -c mirror -rcf xxx -up xxx -z pswd -stv false
-Note: Only what you provide will be edited, the rest will be the same like example 2: exf will stay same as it is.
-Timeout: 60 sec. Argument -c for command and arguments
-            """
-            await edit_message(message, msg, button)
-            pfunc = partial(rss_edit, pre_event=query)
-            await event_handler(client, query, pfunc)
-    elif data[1].startswith("uall"):
-        handler_dict[user_id] = False
-        if len(rss_dict.get(int(data[2]), {})) == 0:
-            await query.answer(text="No subscriptions!", show_alert=True)
-            return
-        await query.answer()
-        if data[1].endswith("unsub"):
-            async with rss_dict_lock:
-                del rss_dict[int(data[2])]
-            await database.rss_delete(int(data[2]))
-            await update_rss_menu(query)
-        elif data[1].endswith("pause"):
-            async with rss_dict_lock:
-                for info in rss_dict[int(data[2])].values():
-                    info["paused"] = True
-            await database.rss_update(int(data[2]))
-        elif data[1].endswith("resume"):
-            async with rss_dict_lock:
-                for info in rss_dict[int(data[2])].values():
-                    info["paused"] = False
-            if scheduler.state == 2:
-                scheduler.resume()
-            await database.rss_update(int(data[2]))
-        await update_rss_menu(query)
-    elif data[1].startswith("all"):
-        if len(rss_dict) == 0:
-            await query.answer(text="No subscriptions!", show_alert=True)
-            return
-        await query.answer()
-        if data[1].endswith("unsub"):
-            async with rss_dict_lock:
-                rss_dict.clear()
-            await database.trunc_table("rss")
-            await update_rss_menu(query)
-        elif data[1].endswith("pause"):
-            async with rss_dict_lock:
-                for user_feeds in rss_dict.values():
-                    for feed in user_feeds.values():
-                        feed["paused"] = True
-            if scheduler.running:
-                scheduler.pause()
-            await database.rss_update_all()
-        elif data[1].endswith("resume"):
-            async with rss_dict_lock:
-                for user_feeds in rss_dict.values():
-                    for feed in user_feeds.values():
-                        feed["paused"] = False
-            if scheduler.state == 2:
-                scheduler.resume()
-            elif not scheduler.running:
-                add_job()
-                scheduler.start()
-                await update_rss_menu(query)
-            await database.rss_update_all()
-    elif data[1] == "deluser":
-        if len(rss_dict) == 0:
-            await query.answer(text="No subscriptions!", show_alert=True)
-        else:
-            await query.answer()
-            buttons = ButtonMaker()
-            buttons.data_button("Back", f"rss back {user_id}")
-            buttons.data_button("Close", f"rss close {user_id}")
-            button = buttons.build_menu(2)
-            msg = "Send one or more user_id separated by space to delete their resources.\nTimeout: 60 sec."
-            await edit_message(message, msg, button)
-            pfunc = partial(rss_delete, pre_event=query)
-            await event_handler(client, query, pfunc)
-    elif data[1] == "listall":
-        if not rss_dict:
-            await query.answer(text="No subscriptions!", show_alert=True)
-        else:
-            await query.answer()
-            start = int(data[3])
-            await rss_list(query, start, all_users=True)
-    elif data[1] == "shutdown":
-        if scheduler.running:
-            await query.answer()
-            scheduler.shutdown(wait=False)
-            await sleep(0.5)
-            await update_rss_menu(query)
-        else:
-            await query.answer(text="Already Stopped!", show_alert=True)
-    elif data[1] == "start":
-        if not scheduler.running:
-            await query.answer()
-            add_job()
-            scheduler.start()
-            await update_rss_menu(query)
-        else:
-            await query.answer(text="Already Running!", show_alert=True)
+        return
+
+    # Simple actions (handlers manage their own query.answer())
+    if action == "close":
+        await _handle_close(query, user_id)
+    elif action == "back":
+        await _handle_back(query, user_id)
+    elif action == "sub":
+        await _handle_sub(client, query, user_id)
+    elif action == "list":
+        await _handle_list(query, user_id, data)
+    elif action == "get":
+        await _handle_get(client, query, user_id, data)
+    elif action in ("unsubscribe", "pause", "resume"):
+        await _handle_feed_action(client, query, user_id, data, action)
+    elif action == "edit":
+        await _handle_edit(client, query, user_id, data)
+    elif action.startswith("uall"):
+        await _handle_user_all(
+            query, user_id, data, action[4:]
+        )  # Extract pause/resume/unsub
+    elif action.startswith("all"):
+        await _handle_all(query, user_id, action[3:])  # Extract pause/resume/unsub
+    elif action == "deluser":
+        await _handle_deluser(client, query, user_id)
+    elif action == "listall":
+        await _handle_listall(query, data)
+    elif action == "shutdown":
+        await _handle_shutdown(query)
+    elif action == "start":
+        await _handle_start(query)
 
 
-async def rss_monitor():
+# ======================== RSS Monitor ========================
+
+
+async def _process_feed_entry(
+    entry: dict,
+    feed_count: int,
+    title: str,
+    data: dict,
+    user: int,
+    rss_chat_id: int | str | None,
+    rss_topic_id: int | str | None,
+) -> bool:
+    """Process a single feed entry. Returns True to continue, False to break."""
+    try:
+        await sleep(10)
+    except Exception:
+        raise RssShutdownException("Rss Monitor Stopped!")
+
+    try:
+        item_title = entry["title"]
+        url = get_entry_link(entry)
+
+        # Check if we've reached the last known item
+        if data["last_feed"] == url or data["last_title"] == item_title:
+            return False
+
+        size = get_entry_size(entry)
+    except IndexError:
+        LOGGER.warning(
+            f"Reached Max index no. {feed_count} for this feed: {title}. Maybe you need to use less RSS_DELAY to not miss some torrents"
+        )
+        return False
+
+    # Apply filters
+    if not check_filters(item_title, data):
+        return True
+
+    # Build and send message
+    if command := data["command"]:
+        if size and Config.RSS_SIZE_LIMIT and Config.RSS_SIZE_LIMIT < size:
+            return True
+        cmd = command.split(maxsplit=1)
+        cmd.insert(1, url)
+        feed_msg = " ".join(cmd)
+        if not feed_msg.startswith("/"):
+            feed_msg = f"/{feed_msg}"
+    else:
+        feed_msg = f"<b>Name: </b><code>{escape_html(item_title)}</code>"
+        feed_msg += f"\n\n<b>Link: </b><code>{url}</code>"
+        if size:
+            feed_msg += f"\n<b>Size: </b>{get_readable_file_size(size)}"
+
+    feed_msg += f"\n<b>Tag: </b><code>{data['tag']}</code> <code>{user}</code>"
+    await send_rss(feed_msg, rss_chat_id, rss_topic_id)
+    return True
+
+
+async def _process_feed(
+    user: int,
+    title: str,
+    data: dict,
+    rss_chat_id: int | str | None,
+    rss_topic_id: int | str | None,
+) -> bool:
+    """Process a single RSS feed. Returns True if feed was active (not paused)."""
+    if data["paused"]:
+        return False
+
+    html = await fetch_rss(data["link"])
+    rss_d = feed_parse(html)
+    if not rss_d.entries:
+        LOGGER.warning(
+            f"No entries found for > Feed Title: {title} - Feed Link: {data['link']}"
+        )
+        return True
+
+    entry0 = rss_d.entries[0]
+    last_link = get_entry_link(entry0)
+    last_title = entry0.get("title", "")
+
+    # No new items
+    if data["last_feed"] == last_link or data["last_title"] == last_title:
+        return True
+
+    # Process new entries
+    for feed_count, entry in enumerate(rss_d.entries):
+        should_continue = await _process_feed_entry(
+            entry, feed_count, title, data, user, rss_chat_id, rss_topic_id
+        )
+        if not should_continue:
+            break
+
+    # Update last seen
+    async with rss_dict_lock:
+        if user in rss_dict and rss_dict[user].get(title):
+            rss_dict[user][title].update(
+                {"last_feed": last_link, "last_title": last_title}
+            )
+
+    await database.rss_update(user)
+    LOGGER.info(f"Feed Name: {title}")
+    LOGGER.info(f"Last item: {last_link}")
+    return True
+
+
+async def rss_monitor() -> None:
     chat = Config.RSS_CHAT
     if not chat:
         LOGGER.warning("RSS_CHAT not added! Shutting down rss scheduler...")
         scheduler.shutdown(wait=False)
         return
-    if len(rss_dict) == 0:
+
+    if not rss_dict:
         scheduler.pause()
         return
+
+    rss_chat_id, rss_topic_id = parse_chat_id(chat)
     all_paused = True
-    rss_topic_id = rss_chat_id = None
-    if isinstance(chat, int):
-        rss_chat_id = chat
-    elif "|" in chat:
-        rss_chat_id, rss_topic_id = list(
-            map(
-                lambda x: int(x) if x.lstrip("-").isdigit() else x,
-                chat.split("|", 1),
-            )
-        )
-    elif chat.lstrip("-").isdigit():
-        rss_chat_id = int(chat)
+
     for user, items in list(rss_dict.items()):
         for title, data in items.items():
             try:
-                if data["paused"]:
-                    continue
-                tries = 0
-                while True:
-                    try:
-                        async with AsyncClient(
-                            headers=headers,
-                            follow_redirects=True,
-                            timeout=60,
-                            verify=False,
-                        ) as client:
-                            res = await client.get(data["link"])
-                        html = res.text
-                        break
-                    except:
-                        tries += 1
-                        if tries > 3:
-                            raise
-                        continue
-                rss_d = feed_parse(html)
-                if not rss_d.entries:
-                    LOGGER.warning(
-                        f"No entries found for > Feed Title: {title} - Feed Link: {data['link']}"
-                    )
-                    continue
-                entry0 = rss_d.entries[0]
-                links = entry0.get("links", [])
-                if len(links) > 1:
-                    last_link = links[1].get("href")
-                elif links:
-                    last_link = links[0].get("href")
-                else:
-                    last_link = entry0.get("link")
-                last_title = entry0.get("title")
-                all_paused = False
-                if data["last_feed"] == last_link or data["last_title"] == last_title:
-                    continue
-                feed_count = 0
-                while True:
-                    try:
-                        await sleep(10)
-                    except:
-                        raise RssShutdownException("Rss Monitor Stopped!")
-                    try:
-                        item_title = rss_d.entries[feed_count]["title"]
-                        try:
-                            url = rss_d.entries[feed_count]["links"][1]["href"]
-                        except IndexError:
-                            url = rss_d.entries[feed_count]["link"]
-                        if data["last_feed"] == url or data["last_title"] == item_title:
-                            break
-                        if rss_d.entries[feed_count].get("size"):
-                            size = int(rss_d.entries[feed_count]["size"])
-                        elif rss_d.entries[feed_count].get("summary"):
-                            summary = rss_d.entries[feed_count]["summary"]
-                            matches = size_regex.findall(summary)
-                            sizes = [match[0] for match in matches]
-                            size = get_size_bytes(sizes[0])
-                        else:
-                            size = 0
-                    except IndexError:
-                        LOGGER.warning(
-                            f"Reached Max index no. {feed_count} for this feed: {title}. Maybe you need to use less RSS_DELAY to not miss some torrents"
-                        )
-                        break
-                    parse = True
-                    for flist in data["inf"]:
-                        if (
-                            data.get("sensitive", False)
-                            and all(x.lower() not in item_title.lower() for x in flist)
-                        ) or (
-                            not data.get("sensitive", False)
-                            and all(x not in item_title for x in flist)
-                        ):
-                            parse = False
-                            feed_count += 1
-                            break
-                    if not parse:
-                        continue
-                    for flist in data["exf"]:
-                        if (
-                            data.get("sensitive", False)
-                            and any(x.lower() in item_title.lower() for x in flist)
-                        ) or (
-                            not data.get("sensitive", False)
-                            and any(x in item_title for x in flist)
-                        ):
-                            parse = False
-                            feed_count += 1
-                            break
-                    if not parse:
-                        continue
-                    if command := data["command"]:
-                        if (
-                            size
-                            and Config.RSS_SIZE_LIMIT
-                            and Config.RSS_SIZE_LIMIT < size
-                        ):
-                            feed_count += 1
-                            continue
-                        cmd = command.split(maxsplit=1)
-                        cmd.insert(1, url)
-                        feed_msg = " ".join(cmd)
-                        if not feed_msg.startswith("/"):
-                            feed_msg = f"/{feed_msg}"
-                    else:
-                        feed_msg = f"<b>Name: </b><code>{item_title.replace('>', '').replace('<', '')}</code>"
-                        feed_msg += f"\n\n<b>Link: </b><code>{url}</code>"
-                        if size:
-                            feed_msg += f"\n<b>Size: </b>{get_readable_file_size(size)}"
-                    feed_msg += (
-                        f"\n<b>Tag: </b><code>{data['tag']}</code> <code>{user}</code>"
-                    )
-                    await send_rss(feed_msg, rss_chat_id, rss_topic_id)
-                    feed_count += 1
-                async with rss_dict_lock:
-                    if user not in rss_dict or not rss_dict[user].get(title, False):
-                        continue
-                    rss_dict[user][title].update(
-                        {"last_feed": last_link, "last_title": last_title}
-                    )
-                await database.rss_update(user)
-                LOGGER.info(f"Feed Name: {title}")
-                LOGGER.info(f"Last item: {last_link}")
+                if await _process_feed(user, title, data, rss_chat_id, rss_topic_id):
+                    all_paused = False
             except RssShutdownException as ex:
                 LOGGER.info(ex)
-                break
+                return
             except Exception as e:
                 LOGGER.error(f"{e} - Feed Name: {title} - Feed Link: {data['link']}")
-                continue
+
     if all_paused:
         scheduler.pause()
 
 
-def add_job():
+# ======================== Scheduler Setup ========================
+
+
+def add_job() -> None:
     scheduler.add_job(
         rss_monitor,
         trigger=IntervalTrigger(seconds=Config.RSS_DELAY),


### PR DESCRIPTION
## Summary

RSS auto-download now calls download handlers directly instead of posting text commands to a Telegram channel, which relied on either a userbot (`USER_SESSION_STRING`) or a channel → linked group forwarding hack to work.

The RSS module has also been rewritten for readability.

### Before
```
RSS feed update → build "/ql https://url -doc" text → send to channel → 
rely on userbot or group forwarding hack → parse text back into args → start download
```

### After
```
RSS feed update → call handler(client, msg) directly → download starts
```
Just set `RSS_CHAT` to any chat the bot is in. Done.

### Changes
- **`bot/modules/rss.py`** — Command map built dynamically from registered Pyrogram handlers. New `_start_rss_download()` sends a notification to `RSS_CHAT` and invokes the handler directly. `is_rss` is now set via a `_rss_trigger` attribute on the message object rather than parsed from `Tag:` text.
- **`bot/helper/common.py`** — Removed `Tag:` text parsing hack and `message.unpin()` workaround from `get_tag()`.
- **`bot/helper/telegram_helper/message_utils.py`** — `send_rss()` uses `TgClient.bot` directly instead of preferring userbot.
- **`README.md`** — Updated `RSS_CHAT` docs.

### What's gone
- No `USER_SESSION_STRING` needed for RSS
- No channel → linked group forwarding setup
- No `Tag: @user 123456` text parsing
- No `message.unpin()` hack

### Backwards compatible
- `RSS_CHAT` config unchanged
- Database format unchanged
- `CMD_SUFFIX` handled automatically
- `is_rss` still suppresses status spam in downloaders

> **Note:** Based on #1901 (empty RSS feed fix), which should be merged first.
