### PR TITLE
Restore cmd_text message for RSS-triggered downloads

### DIFF
--- a/bot/modules/rss.py
+++ b/bot/modules/rss.py
@@ -115,8 +115,7 @@ async def _start_rss_download(
         )
         return
 
-    notify_text = f"<b>RSS Download Started</b>\n<code>{item_title.replace('>', '').replace('<', '')}</code>"
-    msg = await send_rss(notify_text, rss_chat_id, rss_topic_id)
+    msg = await send_rss(cmd_text, rss_chat_id, rss_topic_id)
     if isinstance(msg, str):
         LOGGER.error(f"RSS: Failed to send to RSS_CHAT: {msg}")
         return


### PR DESCRIPTION
This PR restores the previous RSS behavior where the full command text is sent to the RSS chat instead of a generic "RSS Download Started" message.

Before #1904, RSS-triggered downloads were visible in chat as the actual command, for example:

/qm https://... -d 1.0:50 ...

After #1904, the bot only sends:

RSS Download Started
<file name>

and then internally triggers the command handler.

For my use case, the visible command text is important because:
- it shows the exact command and arguments used
- it makes debugging easier
- it allows users to see/copy the original command directly from chat

Changes in this PR:
- remove the generic "RSS Download Started" notification for command-based RSS downloads
- send `cmd_text` to the RSS chat instead
- keep the internal handler execution flow unchanged

This restores the old visible behavior while preserving the new internal trigger logic.