### PR TITLE
Add per-task cancel buttons to status view

### DIFF
--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -229,10 +229,7 @@ async def get_readable_message(sid, is_user, page_no=1, status="All", page_step=
         else:
             msg += f"\n<b>Size: </b>{task.size()}"
         msg += f"\n<code>/{BotCommands.CancelTaskCommand[1]} {task.gid()}</code>\n\n"
-        task_name = task.name()
-        if len(task_name) > 25:
-            task_name = task_name[:25] + "…"
-        task_gids.append((task_name, task.gid()))
+        task_gids.append((index + start_position, task.gid()))
 
     if len(msg) == 0:
         if status == "All":
@@ -256,16 +253,15 @@ async def get_readable_message(sid, is_user, page_no=1, status="All", page_step=
     buttons.data_button("♻️", f"status {sid} ref", position="header")
     button = buttons.build_menu(8)
     if task_gids:
-        cancel_rows = [
-            [
-                InlineKeyboardButton(
-                    text=f"❌ {name}",
-                    callback_data=f"status {sid} cancel {gid}",
-                )
-            ]
-            for name, gid in task_gids
+        cancel_buttons = [
+            InlineKeyboardButton(
+                text=f"❌ {num}",
+                callback_data=f"status {sid} cancel {gid}",
+            )
+            for num, gid in task_gids
         ]
-        button.inline_keyboard.extend(cancel_rows)
+        for i in range(0, len(cancel_buttons), 4):
+            button.inline_keyboard.append(cancel_buttons[i : i + 4])
     msg += f"<b>CPU:</b> {cpu_percent()}% | <b>FREE:</b> {get_readable_file_size(disk_usage(DOWNLOAD_DIR).free)}"
     msg += f"\n<b>RAM:</b> {virtual_memory().percent}% | <b>UPTIME:</b> {get_readable_time(time() - bot_start_time)}"
     return msg, button

--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -5,6 +5,7 @@ from asyncio import iscoroutinefunction, gather
 
 from ... import task_dict, task_dict_lock, bot_start_time, status_dict, DOWNLOAD_DIR
 from ...core.config_manager import Config
+from pyrogram.types import InlineKeyboardButton
 from ..telegram_helper.button_build import ButtonMaker
 from ..telegram_helper.bot_commands import BotCommands
 
@@ -174,6 +175,7 @@ async def get_readable_message(sid, is_user, page_no=1, status="All", page_step=
         status_dict[sid]["page_no"] = page_no
     start_position = (page_no - 1) * STATUS_LIMIT
 
+    task_gids = []
     for index, task in enumerate(
         tasks[start_position : STATUS_LIMIT + start_position], start=1
     ):
@@ -227,6 +229,10 @@ async def get_readable_message(sid, is_user, page_no=1, status="All", page_step=
         else:
             msg += f"\n<b>Size: </b>{task.size()}"
         msg += f"\n<code>/{BotCommands.CancelTaskCommand[1]} {task.gid()}</code>\n\n"
+        task_name = task.name()
+        if len(task_name) > 25:
+            task_name = task_name[:25] + "…"
+        task_gids.append((task_name, task.gid()))
 
     if len(msg) == 0:
         if status == "All":
@@ -249,6 +255,17 @@ async def get_readable_message(sid, is_user, page_no=1, status="All", page_step=
                 buttons.data_button(label, f"status {sid} st {status_value}")
     buttons.data_button("♻️", f"status {sid} ref", position="header")
     button = buttons.build_menu(8)
+    if task_gids:
+        cancel_rows = [
+            [
+                InlineKeyboardButton(
+                    text=f"❌ {name}",
+                    callback_data=f"status {sid} cancel {gid}",
+                )
+            ]
+            for name, gid in task_gids
+        ]
+        button.inline_keyboard.extend(cancel_rows)
     msg += f"<b>CPU:</b> {cpu_percent()}% | <b>FREE:</b> {get_readable_file_size(disk_usage(DOWNLOAD_DIR).free)}"
     msg += f"\n<b>RAM:</b> {virtual_memory().percent}% | <b>UPTIME:</b> {get_readable_time(time() - bot_start_time)}"
     return msg, button

--- a/bot/modules/cancel_task.py
+++ b/bot/modules/cancel_task.py
@@ -94,7 +94,7 @@ def create_cancel_buttons(is_sudo, user_id=""):
         "Uploading", f"canall ms {MirrorStatus.STATUS_UPLOAD} {user_id}"
     )
     buttons.data_button("Seeding", f"canall ms {MirrorStatus.STATUS_SEED} {user_id}")
-    buttons.data_button("Spltting", f"canall ms {MirrorStatus.STATUS_SPLIT} {user_id}")
+    buttons.data_button("Splitting", f"canall ms {MirrorStatus.STATUS_SPLIT} {user_id}")
     buttons.data_button("Cloning", f"canall ms {MirrorStatus.STATUS_CLONE} {user_id}")
     buttons.data_button(
         "Extracting", f"canall ms {MirrorStatus.STATUS_EXTRACT} {user_id}"

--- a/bot/modules/status.py
+++ b/bot/modules/status.py
@@ -197,10 +197,10 @@ async def status_pages(_, query):
                     case _:
                         tasks["Download"] += 1
 
-        msg = f"""<b>DL:</b> {tasks["Download"]} | <b>UP:</b> {tasks["Upload"]} | <b>SD:</b> {tasks["Seed"]} | <b>AR:</b> {tasks["Archive"]}
-<b>EX:</b> {tasks["Extract"]} | <b>SP:</b> {tasks["Split"]} | <b>QD:</b> {tasks["QueueDl"]} | <b>QU:</b> {tasks["QueueUp"]}
-<b>CL:</b> {tasks["Clone"]} | <b>CK:</b> {tasks["CheckUp"]} | <b>PA:</b> {tasks["Pause"]} | <b>SV:</b> {tasks["SamVid"]}
-<b>CM:</b> {tasks["ConvertMedia"]} | <b>FF:</b> {tasks["FFmpeg"]}
+        msg = f"""<b>DL:</b> {tasks['Download']} | <b>UP:</b> {tasks['Upload']} | <b>SD:</b> {tasks['Seed']} | <b>AR:</b> {tasks['Archive']}
+<b>EX:</b> {tasks['Extract']} | <b>SP:</b> {tasks['Split']} | <b>QD:</b> {tasks['QueueDl']} | <b>QU:</b> {tasks['QueueUp']}
+<b>CL:</b> {tasks['Clone']} | <b>CK:</b> {tasks['CheckUp']} | <b>PA:</b> {tasks['Pause']} | <b>SV:</b> {tasks['SamVid']}
+<b>CM:</b> {tasks['ConvertMedia']} | <b>FF:</b> {tasks['FFmpeg']}
 
 <b>ODLS:</b> {get_readable_file_size(dl_speed)}/s
 <b>OULS:</b> {get_readable_file_size(up_speed)}/s

--- a/bot/modules/status.py
+++ b/bot/modules/status.py
@@ -18,9 +18,11 @@ from ..helper.ext_utils.status_utils import (
     MirrorStatus,
     get_readable_file_size,
     get_readable_time,
+    get_task_by_gid,
     speed_string_to_bytes,
 )
 from ..helper.telegram_helper.bot_commands import BotCommands
+from ..helper.telegram_helper.filters import CustomFilters
 from ..helper.telegram_helper.message_utils import (
     send_message,
     delete_message,
@@ -30,6 +32,28 @@ from ..helper.telegram_helper.message_utils import (
     edit_message,
 )
 from ..helper.telegram_helper.button_build import ButtonMaker
+
+
+async def _handle_cancel(query, data, key):
+    gid = data[3] if len(data) > 3 else ""
+    if not gid:
+        await query.answer("Invalid request!", show_alert=True)
+        return
+
+    user_id = query.from_user.id
+    task = await get_task_by_gid(gid)
+    if task is None:
+        await query.answer("Task not found or already finished!", show_alert=True)
+        return
+
+    if task.listener.user_id != user_id and not await CustomFilters.sudo("", query):
+        await query.answer("Not Yours!", show_alert=True)
+        return
+
+    obj = task.task()
+    await obj.cancel_task()
+    await query.answer()
+    await update_status_message(key, force=True)
 
 
 @new_task
@@ -82,6 +106,9 @@ async def get_download_status(download):
 async def status_pages(_, query):
     data = query.data.split()
     key = int(data[1])
+    if data[2] == "cancel":
+        await _handle_cancel(query, data, key)
+        return
     await query.answer()
     if data[2] == "ref":
         await update_status_message(key, force=True)
@@ -170,10 +197,10 @@ async def status_pages(_, query):
                     case _:
                         tasks["Download"] += 1
 
-        msg = f"""<b>DL:</b> {tasks['Download']} | <b>UP:</b> {tasks['Upload']} | <b>SD:</b> {tasks['Seed']} | <b>AR:</b> {tasks['Archive']}
-<b>EX:</b> {tasks['Extract']} | <b>SP:</b> {tasks['Split']} | <b>QD:</b> {tasks['QueueDl']} | <b>QU:</b> {tasks['QueueUp']}
-<b>CL:</b> {tasks['Clone']} | <b>CK:</b> {tasks['CheckUp']} | <b>PA:</b> {tasks['Pause']} | <b>SV:</b> {tasks['SamVid']}
-<b>CM:</b> {tasks['ConvertMedia']} | <b>FF:</b> {tasks['FFmpeg']}
+        msg = f"""<b>DL:</b> {tasks["Download"]} | <b>UP:</b> {tasks["Upload"]} | <b>SD:</b> {tasks["Seed"]} | <b>AR:</b> {tasks["Archive"]}
+<b>EX:</b> {tasks["Extract"]} | <b>SP:</b> {tasks["Split"]} | <b>QD:</b> {tasks["QueueDl"]} | <b>QU:</b> {tasks["QueueUp"]}
+<b>CL:</b> {tasks["Clone"]} | <b>CK:</b> {tasks["CheckUp"]} | <b>PA:</b> {tasks["Pause"]} | <b>SV:</b> {tasks["SamVid"]}
+<b>CM:</b> {tasks["ConvertMedia"]} | <b>FF:</b> {tasks["FFmpeg"]}
 
 <b>ODLS:</b> {get_readable_file_size(dl_speed)}/s
 <b>OULS:</b> {get_readable_file_size(up_speed)}/s


### PR DESCRIPTION
## Summary
- Add ❌ cancel buttons (one per task, showing task number) to the status message, so users can cancel tasks directly instead of copying GIDs
- Cancel buttons appear in compact rows (up to 4 per row) at the bottom of the status view, below navigation/filter buttons
- The existing `/c {gid}` text in each task entry is kept as a fallback
- Permission-checked: only the task owner or sudo users can cancel
- Also fixes "Spltting" → "Splitting" typo in cancel_all buttons

## How it works
1. User opens `/status`
2. Each task on the current page gets a `❌ {number}` button matching its status list number
3. Tapping it cancels the task immediately
4. Status view auto-refreshes after cancellation
