### PR TITLE
Add 'Use This Chat' button to /rss menu for setting RSS_CHAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,8 +439,9 @@ see [Using Service Accounts](https://github.com/anasty17/mirror-leech-telegram-b
 
 - `RSS_SIZE_LIMIT` (`INT`): Item size limit in bytes. Default is `0`.
 
-- `RSS_CHAT` (`Int`|`Str`): Chat `ID or USERNAME or ID|TOPIC_ID or USERNAME|TOPIC_ID` where RSS download results and notifications are posted. The bot must be a member of this chat. Can be a group, supergroup, or user chat. No channel/linked-group setup or `USER_SESSION_STRING` is required. When a command is configured for a subscription (e.g., `-c ql -doc`), downloads start automatically and results are posted here. Without a command, only feed info (name, link, size) is posted.
-    - **RSS NOTES**: `RSS_CHAT` is required, otherwise the RSS monitor will not work. If `DATABASE_URL` is not added you will miss feeds while the bot is offline.
+- `RSS_CHAT`: The RSS monitor requires a chat to post results and notifications. The bot must be a member of this chat. When a command is configured for a subscription (e.g., `-c ql -doc`), downloads start automatically and results are posted here. Without a command, only feed info (name, link, size) is posted.
+    - **Setup**: Run `/rss` in the desired chat and click **Use This Chat** (sudo only). This auto-detects the chat ID and topic. For channels, set the chat ID manually via config/env/bot settings using the format: `ID or USERNAME or ID|TOPIC_ID or USERNAME|TOPIC_ID`.
+    - **Note**: Without `DATABASE_URL`, feeds received while the bot is offline will be missed.
 
 **11. Queue System**
 

--- a/bot/modules/rss.py
+++ b/bot/modules/rss.py
@@ -143,13 +143,32 @@ async def rss_menu(event):
         buttons.data_button("Resume All", f"rss allresume {user_id}")
         buttons.data_button("Unsubscribe All", f"rss allunsub {user_id}")
         buttons.data_button("Delete User", f"rss deluser {user_id}")
+        buttons.data_button("Use This Chat", f"rss setchat {user_id}")
         if scheduler.running:
             buttons.data_button("Shutdown Rss", f"rss shutdown {user_id}")
         else:
             buttons.data_button("Start Rss", f"rss start {user_id}")
     buttons.data_button("Close", f"rss close {user_id}")
     button = buttons.build_menu(2)
-    msg = f"Rss Menu | Users: {len(rss_dict)} | Running: {scheduler.running}"
+    chat = Config.RSS_CHAT
+    if chat:
+        if isinstance(chat, int):
+            rss_id = chat
+        elif "|" in chat:
+            rss_id = chat.split("|", 1)[0]
+            rss_id = int(rss_id) if rss_id.lstrip("-").isdigit() else rss_id
+        elif chat.lstrip("-").isdigit():
+            rss_id = int(chat)
+        else:
+            rss_id = chat
+        event_chat = getattr(event, "chat", None) or event.message.chat
+        if event_chat.id == rss_id:
+            chat_display = "This Chat"
+        else:
+            chat_display = f"<code>{chat}</code>"
+    else:
+        chat_display = "<b>Not Set!</b>"
+    msg = f"Rss Menu | Users: {len(rss_dict)} | Running: {scheduler.running}\nRSS Chat: {chat_display}"
     return msg, button
 
 
@@ -750,6 +769,23 @@ Timeout: 60 sec. Argument -c for command and arguments
             await update_rss_menu(query)
         else:
             await query.answer(text="Already Running!", show_alert=True)
+    elif data[1] == "setchat":
+        chat_id = message.chat.id
+        topic_msg = getattr(message, "topic_message", False)
+        thread_id = message.message_thread_id if topic_msg else None
+        if thread_id:
+            chat_value = f"{chat_id}|{thread_id}"
+        else:
+            chat_value = str(chat_id)
+        old_value = Config.RSS_CHAT
+        Config.set("RSS_CHAT", chat_value)
+        await database.update_config({"RSS_CHAT": chat_value})
+        await query.answer(text=f"RSS_CHAT set to {chat_value}", show_alert=True)
+        if not scheduler.running:
+            add_job()
+            scheduler.start()
+        if str(old_value) != chat_value:
+            await update_rss_menu(query)
 
 
 async def rss_monitor():


### PR DESCRIPTION
## Summary
- Adds a **Use This Chat** button (sudo only) to the `/rss` menu that sets `RSS_CHAT` to the current chat ID, with automatic topic detection for forum groups
- The menu now displays the current `RSS_CHAT` value, showing **This Chat** when invoked in the configured RSS chat
- Auto-restarts the RSS scheduler if it was stopped due to missing `RSS_CHAT`
- Updates README to present the `/rss` menu as the primary setup method for `RSS_CHAT`

## Motivation
Setting up RSS currently requires configuring `RSS_CHAT` through config files, environment variables, or the separate `/bsetting` command — all requiring the user to manually find and enter a chat ID. This adds a one-click setup directly from the `/rss` menu in the target chat.
