### PR TITLE
Fix incorrect info, missing commands, and undocumented config vars in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ Fill up rest of the fields. Meaning of each field is discussed below.
 
 - `DATABASE_URL` (`Str`): Your Mongo Database URL (Connection string). Follow this [Create Database](https://github.com/anasty17/test?tab=readme-ov-file#create-database) to create database. Data will be saved in Database: bot settings, users settings, rss data and incomplete tasks. **NOTE**: You can always edit all settings that saved in database from the official site -> (Browse collections). 
 
+- `DATABASE_NAME` (`Str`): Name of the Mongo database. Default is `mltb`.
+
 - `CMD_SUFFIX` (`Str`|`Int`): Commands index number. This number will added at the end all commands.
 
 - `AUTHORIZED_CHATS` (`Str`): Fill user_id and chat_id of groups/users you want to authorize. To auth only specific topic(s) write it in this format `chat_id|thread_id` Ex:-100XXXXXXXXXXX or -100XXXXXXXXXXX|10 or -100XXXXXXXXXXX|10|12. Separate them by spaces.
@@ -318,6 +320,8 @@ from [Streamwish](https://streamwish.com/?op=my_account).
 - `YT_DLP_OPTIONS` (`Dict`): Dict of yt-dlp options. Check all possible
 options [HERE](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/YoutubeDL.py#L184) or use this [script](https://t.me/mltb_official_channel/177) to convert cli arguments to api options. Format: {key: value, key: value, key: value}.
   - Example: {"format": "bv*+mergeall[vcodec=none]", "nocheckcertificate": True, "playliststart": 10, "fragment_retries": float("inf"), "matchtitle": "S13", "writesubtitles": True, "live_from_start": True, "postprocessor_args": {"ffmpeg": ["-threads", "4"]}, "wait_for_video": (5, 100), "download_ranges": [{"start_time": 0, "end_time": 10}]}
+
+- `GALLERY_DL_OPTIONS` (`Dict`): Dict of gallery-dl options. Supports custom gallery-dl options globally, per user, and per task. Format: {key: value, key: value}.
 
 - `USE_SERVICE_ACCOUNTS` (`Bool`): Whether to use Service Accounts or not, with google-api-python-client. For this to work
 see [Using Service Accounts](https://github.com/anasty17/mirror-leech-telegram-bot#generate-service-accounts-what-is-service-account) section below. Default is `False`.
@@ -382,7 +386,7 @@ see [Using Service Accounts](https://github.com/anasty17/mirror-leech-telegram-b
 
 **6. Leech**
 
-- `LEECH_SPLIT_SIZE` (`Int`): Size of split in bytes. Default is `2GB`. Default is `4GB` if your account is premium.
+- `LEECH_SPLIT_SIZE` (`Int`): Size of split in bytes. Default is `~2GB` (2000 MiB). Default is `~4GB` (4000 MiB) if your account is premium.
 
 - `AS_DOCUMENT` (`Bool`): Default type of Telegram file upload. Default is `False` mean as media.
 
@@ -611,11 +615,13 @@ qbmirror - or /qm Mirror torrent using qBittorrent
 jdmirror - or /jm Mirror using jdownloader
 nzbmirror - or /nm Mirror using sabnzbd
 ytdl - or /y Mirror yt-dlp supported links
+gallerydl - or /gdl Mirror using gallery-dl
 leech - or /l Upload to telegram
 qbleech - or /ql Leech torrent using qBittorrent
 jdleech - or /jl Leech using jdownloader
 nzbleech - or /nl Leech using sabnzbd
 ytdlleech - or /yl Leech yt-dlp supported links
+gallerydlleech - or /gdlleech Leech using gallery-dl
 clone - Copy file/folder to Drive
 count - Count file/folder from GDrive
 usetting - or /us User settings
@@ -625,6 +631,7 @@ sel - Select files from torrent
 rss - Rss menu
 list - Search files in Drive
 search - Search for torrents with API
+nzbsearch - Search for NZBs
 cancel - or /c Cancel a task
 cancelall - Cancel all tasks
 forcestart - or /fs to start task from queue
@@ -632,11 +639,14 @@ del - Delete file/folder from GDrive
 log - Get the Bot Log
 auth - Authorize user or chat
 unauth - Unauthorize uer or chat
+addsudo - Add sudo user
+rmsudo - Remove sudo user
+users - Show users settings
 shell - Run commands in Shell
 aexec - Execute async function
 exec - Execute sync function
+clearlocals - Clear exec locals
 restart - Restart the Bot
-restartses - Restart Telegram Session(s)
 stats - Bot Usage Stats
 ping - Ping the Bot
 help - All cmds with description
@@ -747,7 +757,7 @@ python3 generate_drive_token.py
 <details>
   <summary><h3>Aria2c</h3></summary>
 
-- Global options: `--seed-ratio` (0 means no limit) and `--seed-time` (0 means no seed) in aria.sh.
+- Global options: `--seed-ratio` (0 means no limit) in aria-nox-nzb.sh.
 
 ------
 
@@ -757,7 +767,7 @@ python3 generate_drive_token.py
 <details>
   <summary><h5>Using Service Accounts for uploading to avoid user rate limit</h5></summary>
 
-> For Service Account to work, you must set `USE_SERVICE_ACCOUNTS` = "True" in config file or environment variables.
+> For Service Account to work, you must set `USE_SERVICE_ACCOUNTS` = `True` in config file or environment variables.
 > **NOTE**: Using Service Accounts is only recommended while uploading to a Team Drive.
 
 <details>


### PR DESCRIPTION
## Summary
Fix incorrect information, add missing commands, and document undocumented config variables in README.

## Changes

### Wrong file reference and incorrect claim
- `aria.sh` does not exist, corrected to `aria-nox-nzb.sh`
- Removed `--seed-time` mention (not present in the file, only `--seed-ratio` is a global option there)

### Missing bot commands added to BotFather list
- `gallerydl` / `gdl` — Mirror using gallery-dl
- `gallerydlleech` / `gdlleech` — Leech using gallery-dl
- `nzbsearch` — Search for NZBs
- `addsudo` — Add sudo user
- `rmsudo` — Remove sudo user
- `users` — Show users settings
- `clearlocals` — Clear exec locals

All 7 commands are fully implemented with handlers registered in `handlers.py`.

### Removed nonexistent command
- `restartses` — no such command exists in the codebase

### Undocumented config variables added
- `DATABASE_NAME` (`Str`): exists in `config_sample.py`, default `mltb`
- `GALLERY_DL_OPTIONS` (`Dict`): exists in `config_sample.py`, used for gallery-dl configuration

### Other fixes
- `LEECH_SPLIT_SIZE` default clarified from `2GB` to `~2GB (2000 MiB)` to match actual value (`2097152000` bytes)
- `USE_SERVICE_ACCOUNTS` = `"True"` (string) corrected to `True` (Bool) to match the actual type
