### PR TITLE
Add cookie-aware Terabox direct link generator with recursive crawl

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -784,10 +784,278 @@ def uploadee(url):
 
 
 def terabox(url):
-    
+
     if "/file/" in url:
         return url
-    
+
+    COOKIE_DOMAINS = (
+        "terabox", "1024tera", "freeterabox", "nephobox", "4funbox",
+        "mirrobox", "momerybox", "gibibox", "goaibox", "teraboxapp",
+        "terasharelink", "teraboxlink", "teraboxshare", "terafileshare",
+    )
+    API_PARAMS = {
+        "app_id": "250528", "web": "1", "channel": "dubox", "clienttype": "0",
+    }
+
+    def __load_cookies():
+        if not ospath.isfile("cookies.txt"):
+            return None
+        cookies = {}
+        try:
+            with open("cookies.txt") as f:
+                for line in f:
+                    line = line.rstrip("\r\n")
+                    if line.startswith("#HttpOnly_"):
+                        line = line[len("#HttpOnly_"):]
+                    if not line or line.startswith("#"):
+                        continue
+                    parts = line.split("\t")
+                    if len(parts) < 7:
+                        continue
+                    if not any(k in parts[0].lower() for k in COOKIE_DOMAINS):
+                        continue
+                    cookies[parts[5]] = parts[6]
+        except Exception:
+            return None
+        if not cookies.get("BDUSS") and not cookies.get("ndus"):
+            return None
+        return cookies
+
+    def __parse_share(share_url):
+        parsed = urlparse(share_url)
+        qs = parse_qs(parsed.query)
+        password = (qs.get("pwd") or [""])[0]
+        surl = ""
+        if "surl" in qs:
+            surl = qs["surl"][0]
+        elif "/s/" in parsed.path:
+            surl = parsed.path.split("/s/", 1)[1].split("/", 1)[0]
+        if surl.startswith("1") and len(surl) > 20:
+            surl = surl[1:]
+        if not surl:
+            raise DirectDownloadLinkException(
+                "ERROR: Could not parse Terabox share URL"
+            )
+        return surl, password
+
+    def __bootstrap(session, surl, password):
+        try:
+            resp = session.get(
+                f"https://www.terabox.com/sharing/link?surl={surl}",
+                timeout=30, allow_redirects=True,
+            )
+        except Exception as e:
+            raise DirectDownloadLinkException(
+                f"ERROR: {e.__class__.__name__}"
+            ) from e
+        html_text = resp.text
+        m = search(r'fn%28%22([0-9A-F]+)%22%29', html_text) or \
+            search(r'fn\("([0-9A-F]+)"\)', html_text)
+        if not m:
+            raise DirectDownloadLinkException(
+                "ERROR: jsToken not found (login expired?)"
+            )
+        js_token = m.group(1)
+        pcf = search(r'pcftoken["\']?\s*[:=]\s*["\']([0-9a-f]+)', html_text)
+        pcftoken = pcf.group(1) if pcf else "0"
+        if password:
+            try:
+                v = session.post(
+                    f"https://{resp.url.split('/')[2]}/share/verify",
+                    params={**API_PARAMS, "surl": surl},
+                    data={"pwd": password},
+                    timeout=30,
+                ).json()
+                if v.get("errno") != 0:
+                    raise DirectDownloadLinkException(
+                        f"ERROR: Share password verification failed "
+                        f"(errno={v.get('errno')})"
+                    )
+            except DirectDownloadLinkException:
+                raise
+            except Exception as e:
+                raise DirectDownloadLinkException(
+                    f"ERROR: {e.__class__.__name__}"
+                ) from e
+        return js_token, pcftoken
+
+    def __share_list(session, surl, js_token, pcftoken, *, dir_path=None,
+                     root=False, page=1, num=200):
+        params = {
+            **API_PARAMS, "jsToken": js_token, "pcftoken": pcftoken,
+            "shorturl": surl, "page": str(page), "num": str(num),
+            "by": "name", "order": "asc", "scene": "",
+        }
+        if root:
+            params["root"] = "1"
+        if dir_path is not None:
+            params["dir"] = dir_path
+        try:
+            data = session.get(
+                "https://dm.terabox.com/share/list",
+                params=params, timeout=30,
+            ).json()
+        except Exception as e:
+            raise DirectDownloadLinkException(
+                f"ERROR: {e.__class__.__name__}"
+            ) from e
+        if data.get("errno") not in (0, None):
+            raise DirectDownloadLinkException(
+                f"ERROR: share/list errno={data.get('errno')}"
+            )
+        return data
+
+    def __shorturlinfo(session, surl, js_token):
+        try:
+            data = session.get(
+                "https://www.terabox.com/api/shorturlinfo",
+                params={
+                    **API_PARAMS, "jsToken": js_token,
+                    "shorturl": "1" + surl, "root": "1",
+                    "page": "1", "num": "20",
+                },
+                timeout=30,
+            ).json()
+        except Exception as e:
+            raise DirectDownloadLinkException(
+                f"ERROR: {e.__class__.__name__}"
+            ) from e
+        if data.get("errno") not in (0, None):
+            raise DirectDownloadLinkException(
+                f"ERROR: shorturlinfo errno={data.get('errno')}"
+            )
+        return data
+
+    def __resolve_dlinks(session, js_token, meta, fs_ids):
+        out = {}
+        for fid in fs_ids:
+            try:
+                data = session.post(
+                    "https://www.terabox.com/share/download",
+                    params={
+                        **API_PARAMS, "jsToken": js_token,
+                        "sign": meta["sign"],
+                        "timestamp": str(meta["timestamp"]),
+                    },
+                    data={
+                        "shareid": str(meta["shareid"]),
+                        "uk": str(meta["uk"]),
+                        "product": "share",
+                        "fid_list": "[" + str(fid) + "]",
+                        "primaryid": str(meta["shareid"]),
+                        "type": "nolimit",
+                    },
+                    timeout=30,
+                ).json()
+            except Exception as e:
+                raise DirectDownloadLinkException(
+                    f"ERROR: {e.__class__.__name__}"
+                ) from e
+            if data.get("errno") not in (0, None):
+                raise DirectDownloadLinkException(
+                    f"ERROR: share/download errno={data.get('errno')}"
+                )
+            if data.get("dlink"):
+                out[fid] = data["dlink"]
+            sleep(0.3)
+        return out
+
+    def __crawl_with_cookies(cookies):
+        surl, password = __parse_share(url)
+        session = Session()
+        session.cookies.update(cookies)
+        session.headers.update({
+            "User-Agent": user_agent,
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": f"https://www.terabox.com/sharing/link?surl={surl}",
+        })
+        js_token, pcftoken = __bootstrap(session, surl, password)
+        info = __shorturlinfo(session, surl, js_token)
+        meta = {
+            "sign": info.get("sign", ""),
+            "timestamp": info.get("timestamp", ""),
+            "shareid": info.get("shareid") or info.get("share_id"),
+            "uk": info.get("uk"),
+        }
+        details = {"contents": [], "title": "", "total_size": 0}
+        pending = []
+
+        def __walk(dir_path=None, root=False):
+            page = 1
+            while True:
+                data = __share_list(
+                    session, surl, js_token, pcftoken,
+                    dir_path=dir_path, root=root, page=page, num=200,
+                )
+                if root and page == 1 and not details["title"]:
+                    details["title"] = (data.get("title") or surl).lstrip("/")
+                items = data.get("list") or []
+                if not items:
+                    break
+                for it in items:
+                    if int(it.get("isdir") or 0):
+                        __walk(dir_path=it["path"])
+                    else:
+                        entry = {
+                            "path": ospath.dirname(it.get("path", "")).lstrip("/"),
+                            "filename": it["server_filename"],
+                            "url": it.get("dlink", ""),
+                        }
+                        details["contents"].append(entry)
+                        details["total_size"] += int(it.get("size") or 0)
+                        if not entry["url"]:
+                            pending.append(
+                                (int(it["fs_id"]), len(details["contents"]) - 1)
+                            )
+                if len(items) < 200:
+                    break
+                page += 1
+                sleep(0.3)
+
+        __walk(root=True)
+
+        if pending:
+            resolved = __resolve_dlinks(
+                session, js_token, meta, [fid for fid, _ in pending]
+            )
+            for fid, idx in pending:
+                if fid in resolved:
+                    details["contents"][idx]["url"] = resolved[fid]
+            missing = [details["contents"][idx]["filename"]
+                       for fid, idx in pending if fid not in resolved]
+            if missing:
+                raise DirectDownloadLinkException(
+                    f"ERROR: failed to resolve dlink for {len(missing)} "
+                    f"file(s); first: {missing[0]}"
+                )
+
+        if not details["contents"]:
+            raise DirectDownloadLinkException(
+                "ERROR: Empty share or invalid cookies"
+            )
+        if not details["title"]:
+            details["title"] = details["contents"][0]["filename"]
+
+        cookie_header = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        details["header"] = (
+            f"Cookie: {cookie_header}\n"
+            f"User-Agent: {user_agent}\n"
+            f"Referer: https://www.terabox.com/"
+        )
+        if len(details["contents"]) == 1:
+            return details["contents"][0]["url"], details["header"]
+        return details
+
+    cookies = __load_cookies()
+    if cookies:
+        try:
+            return __crawl_with_cookies(cookies)
+        except DirectDownloadLinkException:
+            raise
+        except Exception:
+            pass
+
     api_url = "https://teraboxdl.site/api/proxy"
     headers = {"Referer": "https://teraboxdl.site/", "User-Agent": user_agent}
     payload = {"url": url}
@@ -817,6 +1085,7 @@ def terabox(url):
     if len(details["contents"]) == 1:
         return details["contents"][0]["url"]
     return details
+
 
 
 def filepress(url):


### PR DESCRIPTION
## Summary

Currently `terabox()` proxies through `teraboxdl.site/api/proxy`, which
flattens the share to root-level files and depends on a third-party
service. This PR teaches `terabox()` to use an authenticated session
when `cookies.txt` is present, so users with a Terabox account get the
full folder tree.

- Reads `cookies.txt` (the same file already used by yt-dlp and
  gallery-dl) and looks for a Terabox-family auth cookie (`BDUSS` or
  `ndus`).
- Bootstraps `jsToken` and `pcftoken` from the share landing page,
  supports password-protected shares via `/share/verify`, then walks
  `/share/list` recursively (200 items per page) into every sub-folder.
- Resolves a per-file `dlink` via `/share/download` (signed with the
  timestamp from `/api/shorturlinfo`) since some accounts/shares omit
  `dlink` from the listing payload.
- Returns `details` in the same shape as `gofile()` and includes a
  `header` field with `Cookie`/`User-Agent`/`Referer` so aria2 can
  follow the dlink.
- Falls back to the previous `teraboxdl.site` flow when `cookies.txt`
  is missing or has no Terabox auth cookie, so behavior for users
  without an account is unchanged.

## Implementation notes

- The cookie file is parsed manually rather than via
  `MozillaCookieJar`, because Cookie-Editor and similar extensions
  write the `ndus` cookie with a leading `#HttpOnly_` marker that the
  cookiejar treats as a comment and silently drops.
- `isdir` and `size` are cast to `int`; the `/share/list` response
  returns them as strings on some accounts, which would otherwise make
  files look like folders.
- `/share/download` is called once per `fs_id`; multi-fid requests
  collapse to a batch ZIP link rather than per-file dlinks.
- All helpers are nested inside `terabox()` to mirror the structure of
  `gofile()` and keep the module surface unchanged.

## Test plan

- [x] Folder share with multiple sub-folders crawled end-to-end (38
      files / 3.12 GiB and 4 files / 361 MiB on two different accounts)
- [x] `cookies.txt` with `#HttpOnly_` lines parsed correctly
- [x] Single-file share returns `(url, header)` tuple
- [x] Missing `cookies.txt` falls back to `teraboxdl.site`
- [ ] Password-protected share (code path present, not exercised in my
      smoke tests — please verify if you have a sample link)