### PR TITLE
Add ouo.io / ouo.press shortlink bypass

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -18,6 +18,7 @@ from ...ext_utils.exceptions import DirectDownloadLinkException
 from ...ext_utils.help_messages import PASSWORD_ERROR_MESSAGE
 from ...ext_utils.links_utils import is_share_link
 from ...ext_utils.status_utils import speed_string_to_bytes
+from .url_shortener_bypass import bypass_shortener, is_url_shortener
 
 user_agent = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0"
@@ -29,6 +30,14 @@ def direct_link_generator(link):
     domain = urlparse(link).hostname
     if not domain:
         raise DirectDownloadLinkException("ERROR: Invalid URL")
+    elif is_url_shortener(domain):
+        resolved = bypass_shortener(link)
+        try:
+            return direct_link_generator(resolved)
+        except DirectDownloadLinkException as e:
+            if str(e).startswith("ERROR: No Direct link function found"):
+                return resolved
+            raise
     elif "yadi.sk" in link or "disk.yandex." in link:
         return yandex_disk(link)
     elif "buzzheavier.com" in domain:

--- a/bot/helper/mirror_leech_utils/download_utils/url_shortener_bypass.py
+++ b/bot/helper/mirror_leech_utils/download_utils/url_shortener_bypass.py
@@ -55,7 +55,7 @@ def _ouo(link):
     parsed = urlparse(normalized)
     short_id = parsed.path.rsplit("/", 1)[-1]
     if not short_id:
-        raise DirectDownloadLinkException("ERROR: ouo: id segment kosong")
+        raise DirectDownloadLinkException("ERROR: ouo: empty id segment")
 
     base = f"{parsed.scheme}://{parsed.netloc}"
     go_url = f"{base}/go/{short_id}"
@@ -66,12 +66,12 @@ def _ouo(link):
             r1 = s.get(normalized, allow_redirects=True)
             if r1.status_code == 403:
                 raise DirectDownloadLinkException(
-                    "ERROR: ouo.io memblokir request (403)"
+                    "ERROR: ouo.io blocked the request (403)"
                 )
             tok1 = _extract_csrf(r1.text)
             if not tok1:
                 raise DirectDownloadLinkException(
-                    f"ERROR: ouo: _token tidak ditemukan di halaman awal (status={r1.status_code})"
+                    f"ERROR: ouo: _token not found on initial page (status={r1.status_code})"
                 )
 
             r2 = s.post(
@@ -82,7 +82,7 @@ def _ouo(link):
             )
             if r2.status_code == 403:
                 raise DirectDownloadLinkException(
-                    "ERROR: ouo.io memblokir request (403)"
+                    "ERROR: ouo.io blocked the request (403)"
                 )
             if r2.status_code != 200:
                 raise DirectDownloadLinkException(
@@ -91,7 +91,7 @@ def _ouo(link):
             tok2 = _extract_csrf(r2.text)
             if not tok2:
                 raise DirectDownloadLinkException(
-                    "ERROR: ouo: _token tidak ditemukan di halaman /go/"
+                    "ERROR: ouo: _token not found on /go/ page"
                 )
 
             r3 = s.post(
@@ -109,4 +109,4 @@ def _ouo(link):
     except DirectDownloadLinkException:
         raise
     except Exception as e:
-        raise DirectDownloadLinkException(f"ERROR: ouo bypass gagal: {e}") from e
+        raise DirectDownloadLinkException(f"ERROR: ouo bypass failed: {e}") from e

--- a/bot/helper/mirror_leech_utils/download_utils/url_shortener_bypass.py
+++ b/bot/helper/mirror_leech_utils/download_utils/url_shortener_bypass.py
@@ -1,0 +1,112 @@
+"""URL shortener bypassers.
+
+Each handler resolves a shortened URL back to its underlying target URL.
+Handlers are pure resolvers: input a shortened URL, output the target URL
+string (or raise DirectDownloadLinkException). The caller in
+direct_link_generator.py is responsible for re-dispatching the returned URL
+through the regular host handlers.
+"""
+
+from re import search
+from urllib.parse import urlparse
+
+from curl_cffi import requests as cffi_requests
+
+from ...ext_utils.exceptions import DirectDownloadLinkException
+
+
+_OUO_DOMAINS = ("ouo.io", "ouo.press")
+
+_CSRF_PATTERN = (
+    r'<input[^>]*\bname="_token"[^>]*\bvalue="([^"]*)"'
+    r'|<input[^>]*\bvalue="([^"]*)"[^>]*\bname="_token"'
+)
+
+
+def is_url_shortener(domain):
+    if not domain:
+        return False
+    return any(d in domain for d in _OUO_DOMAINS)
+
+
+def bypass_shortener(link):
+    domain = urlparse(link).hostname or ""
+    if any(d in domain for d in _OUO_DOMAINS):
+        return _ouo(link)
+    raise DirectDownloadLinkException(f"ERROR: No bypasser for {domain}")
+
+
+def _extract_csrf(html):
+    m = search(_CSRF_PATTERN, html)
+    if not m:
+        return ""
+    return next((g for g in m.groups() if g), "")
+
+
+def _ouo(link):
+    """Resolve ouo.io / ouo.press shortlinks.
+
+    Three-step CSRF dance: GET landing → POST /go/<id> → POST /xreallcygo/<id>.
+    Cloudflare fronts ouo.io and fingerprints both TLS ClientHello and HTTP/2
+    SETTINGS, so curl_cffi's chrome impersonation is required — stdlib
+    requests/httpx gets 403.
+    """
+    normalized = link.replace("ouo.press", "ouo.io")
+    parsed = urlparse(normalized)
+    short_id = parsed.path.rsplit("/", 1)[-1]
+    if not short_id:
+        raise DirectDownloadLinkException("ERROR: ouo: id segment kosong")
+
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    go_url = f"{base}/go/{short_id}"
+    final_url = f"{base}/xreallcygo/{short_id}"
+
+    try:
+        with cffi_requests.Session(impersonate="chrome136", timeout=30) as s:
+            r1 = s.get(normalized, allow_redirects=True)
+            if r1.status_code == 403:
+                raise DirectDownloadLinkException(
+                    "ERROR: ouo.io memblokir request (403)"
+                )
+            tok1 = _extract_csrf(r1.text)
+            if not tok1:
+                raise DirectDownloadLinkException(
+                    f"ERROR: ouo: _token tidak ditemukan di halaman awal (status={r1.status_code})"
+                )
+
+            r2 = s.post(
+                go_url,
+                data={"_token": tok1, "x-token": "", "v-token": "vm"},
+                headers={"Origin": "https://ouo.io", "Referer": normalized},
+                allow_redirects=False,
+            )
+            if r2.status_code == 403:
+                raise DirectDownloadLinkException(
+                    "ERROR: ouo.io memblokir request (403)"
+                )
+            if r2.status_code != 200:
+                raise DirectDownloadLinkException(
+                    f"ERROR: ouo: /go/ status {r2.status_code}"
+                )
+            tok2 = _extract_csrf(r2.text)
+            if not tok2:
+                raise DirectDownloadLinkException(
+                    "ERROR: ouo: _token tidak ditemukan di halaman /go/"
+                )
+
+            r3 = s.post(
+                final_url,
+                data={"_token": tok2, "x-token": ""},
+                headers={"Origin": "https://ouo.io", "Referer": go_url},
+                allow_redirects=False,
+            )
+            location = r3.headers.get("Location", "")
+            if r3.status_code != 302 or not location:
+                raise DirectDownloadLinkException(
+                    f"ERROR: ouo: /xreallcygo/ status {r3.status_code} (location={location!r})"
+                )
+            return location
+    except DirectDownloadLinkException:
+        raise
+    except Exception as e:
+        raise DirectDownloadLinkException(f"ERROR: ouo bypass gagal: {e}") from e


### PR DESCRIPTION
## Summary

Adds a URL shortener bypass step to `direct_link_generator` so `/mirror` and `/leech` accept ouo.io / ouo.press shortlinks directly, then recursively re-resolve the underlying target URL through the existing host handlers.

- New module `bot/helper/mirror_leech_utils/download_utils/url_shortener_bypass.py` with a pluggable structure (`is_url_shortener` + `bypass_shortener` dispatcher) so additional shorteners can be added without touching `direct_link_generator.py`.
- ouo handler performs the three-step CSRF dance (`GET /<id>` → `POST /go/<id>` → `POST /xreallcygo/<id>`) using `curl_cffi` with `impersonate="chrome136"`. Chrome TLS + HTTP/2 fingerprinting is required because Cloudflare fronts ouo.io and 403s stdlib clients (and the latest profiles `chrome` / `chrome142` are also currently blocked).
- `direct_link_generator()` gains a single new branch up front: when the host is a shortener, resolve and recurse. If the resolved target has no host handler (e.g. it's already a direct file URL), the resolved URL is returned as-is so aria2 can pick it up.

`curl_cffi` is already a dependency via `yt-dlp[curl-cffi]` — no new requirements.

## Behavior preserved

- Argument flags (`-e`, `-z`, `-m`, `-n`, `-up`, etc.) are unaffected — bypass only mutates `self.link` inside `direct_link_generator`; all listener attributes are set earlier in `Mirror.new_event()`.
- Errors raised by downstream host handlers (e.g. password-protected Terabox, R.I.P hosts) propagate normally.

## Test plan

- [x] Pure-logic unit checks: domain matcher (`ouo.io`, `www.ouo.io`, `ouo.press`, mediafire negative), CSRF regex with both attribute orders, id parsing including `ouo.press → ouo.io` normalization.
- [x] End-to-end live resolve inside the running bot container: `https://ouo.io/OHYvxIy` → `https://1024terabox.com/s/1A7A8Ani1t86QSgeR66jTwA`, then handed off to the existing `terabox()` handler via recursion.
- [ ] (Maintainer) Verify on a fresh ouo link of your choice; some Cloudflare profiles drift over time.

## Adding more shorteners

1. Add the domain to `_*_DOMAINS` and the `bypass_shortener` dispatcher in `url_shortener_bypass.py`.
2. Implement `_xxx(link)` returning the resolved URL (or raising `DirectDownloadLinkException`).

No changes needed in `direct_link_generator.py`.