### PR TITLE
Add Yes/No confirmation dialog for task cancel buttons

### DIFF
--- a/bot/helper/telegram_helper/message_utils.py
+++ b/bot/helper/telegram_helper/message_utils.py
@@ -188,6 +188,8 @@ async def update_status_message(sid, force=False):
                 obj.cancel()
                 del intervals["status"][sid]
             return
+        if status_dict[sid].get("confirm_gid"):
+            return
         if not force and time() - status_dict[sid]["time"] < 3:
             return
         status_dict[sid]["time"] = time()

--- a/bot/modules/status.py
+++ b/bot/modules/status.py
@@ -1,3 +1,4 @@
+from html import escape
 from psutil import cpu_percent, virtual_memory, disk_usage
 from time import time
 from asyncio import gather, iscoroutinefunction
@@ -34,6 +35,22 @@ from ..helper.telegram_helper.message_utils import (
 from ..helper.telegram_helper.button_build import ButtonMaker
 
 
+async def _show_cancel_confirm(query, key, gid, task):
+    button = ButtonMaker()
+    button.data_button("Yes", f"status {key} canyes {gid}")
+    button.data_button("No", f"status {key} canno")
+    name = escape(task.name())
+    msg = (
+        f"<b>Cancel this task?</b>\n\n"
+        f"<code>{name}</code>\n"
+        f"<b>Gid:</b> <code>{gid}</code>"
+    )
+    async with task_dict_lock:
+        if key in status_dict:
+            status_dict[key]["confirm_gid"] = gid
+    await edit_message(query.message, msg, button.build_menu(2))
+
+
 async def _handle_cancel(query, data, key):
     gid = data[3] if len(data) > 3 else ""
     if not gid:
@@ -48,8 +65,38 @@ async def _handle_cancel(query, data, key):
         await query.answer("Not Yours!", show_alert=True)
         return
     await query.answer()
+    await _show_cancel_confirm(query, key, gid, task)
+
+
+async def _handle_cancel_confirm(query, data, key):
+    gid = data[3] if len(data) > 3 else ""
+    if not gid:
+        await query.answer("Invalid request!", show_alert=True)
+        return
+    user_id = query.from_user.id
+    task = await get_task_by_gid(gid)
+    async with task_dict_lock:
+        if key in status_dict:
+            status_dict[key].pop("confirm_gid", None)
+    if task is None:
+        await query.answer("Task not found or already finished!", show_alert=True)
+        await update_status_message(key, force=True)
+        return
+    if task.listener.user_id != user_id and not await CustomFilters.sudo("", query):
+        await query.answer("Not Yours!", show_alert=True)
+        await update_status_message(key, force=True)
+        return
+    await query.answer("Cancelling...")
     obj = task.task()
     await obj.cancel_task()
+    await update_status_message(key, force=True)
+
+
+async def _handle_cancel_abort(query, key):
+    async with task_dict_lock:
+        if key in status_dict:
+            status_dict[key].pop("confirm_gid", None)
+    await query.answer()
     await update_status_message(key, force=True)
 
 
@@ -105,6 +152,12 @@ async def status_pages(_, query):
     key = int(data[1])
     if data[2] == "cancel":
         await _handle_cancel(query, data, key)
+        return
+    if data[2] == "canyes":
+        await _handle_cancel_confirm(query, data, key)
+        return
+    if data[2] == "canno":
+        await _handle_cancel_abort(query, key)
         return
     await query.answer()
     if data[2] == "ref":


### PR DESCRIPTION
## Summary

Users sometimes accidentally tap the per-task ❌ cancel buttons under the status message and lose in-progress work. This adds a confirmation step.

When a user taps ❌ next to a task, the status message is edited to show only that task (name + GID) with **Yes** / **No** buttons. **No** restores the normal status view; **Yes** cancels the task and refreshes the status.

While the confirmation dialog is showing, the periodic status auto-refresh is paused for that status message via a `confirm_gid` flag in `status_dict`, so the dialog isn't overwritten by the next refresh tick.

Authorization (`Not Yours!`) is still checked at both the initial tap and the Yes confirmation.

## Test plan

- [ ] Start a task, open `/status`, tap ❌ next to the task — dialog appears with task name and Yes/No
- [ ] Tap **No** — status returns to normal, task continues running
- [ ] Tap ❌ again, then **Yes** — task is cancelled, status returns to normal
- [ ] While the dialog is shown, confirm the periodic status refresh does not overwrite it
- [ ] Tap ❌ on another user's task as a non-sudo user — get "Not Yours!" alert
- [ ] Tap **Yes** after the task already finished — get "Task not found or already finished!" and status refreshes