### PR TITLE
feat(torbox): add -tb support for magnets, torrents, and web downloads

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -7,6 +7,7 @@ from bot import LOGGER
 
 class Config:
     ALLDEBRID_API_KEY = ""
+    TORBOX_API_KEY = ""
     AS_DOCUMENT = False
     AUTHORIZED_CHATS = ""
     BASE_URL = ""

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -88,6 +88,8 @@ class TaskConfig:
         self.subsize = 0
         self.proceed_count = 0
         self._alldebrid_magnet_id = 0
+        self._torbox_torrent_id = 0
+        self._torbox_web_id = 0
         self.is_leech = False
         self.is_qbit = False
         self.is_nzb = False
@@ -96,6 +98,7 @@ class TaskConfig:
         self.is_ytdlp = False
         self.is_gallerydl = False
         self.is_alldebrid = False
+        self.is_torbox = False
         self.is_buzzheavier = False
         self.is_gofile = False
         self.equal_splits = False

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -116,6 +116,7 @@ def arg_parser(items, arg_base):
         "-ut",
         "-bt",
         "-ad",
+        "-tb",
     }
 
     while i < total:
@@ -142,6 +143,7 @@ def arg_parser(items, arg_base):
                     "-ut",
                     "-bt",
                     "-ad",
+                    "-tb",
                 ]
             ):
                 arg_base[part] = True

--- a/bot/helper/ext_utils/help_messages.py
+++ b/bot/helper/ext_utils/help_messages.py
@@ -301,6 +301,17 @@ entirely so dead torrents finish faster on a debrid plan.
 
 Requires <code>ALLDEBRID_API_KEY</code> in the bot configuration."""
 
+torbox_arg = """<b>TorBox Unlock</b>: -tb
+
+/cmd link -tb
+Routes normal web/filehost links through TorBox WebDL.
+
+Magnet/torrent inputs are also routed through TorBox when <code>-tb</code>
+is set: the bot uploads the magnet or replied <code>.torrent</code>,
+waits for TorBox to finish/cache it, then downloads each file from TorBox CDN links.
+
+Requires <code>TORBOX_API_KEY</code> in bot configuration."""
+
 YT_HELP_DICT = {
     "main": yt,
     "New-Name": f"{new_name}\nNote: Don't add file extension",
@@ -377,6 +388,7 @@ MIRROR_HELP_DICT = {
     "Leech-Type": leech_as,
     "FFmpeg-Cmds": ffmpeg_cmds,
     "AllDebrid": alldebrid_arg,
+    "TorBox": torbox_arg,
 }
 
 CLONE_HELP_DICT = {

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -455,6 +455,28 @@ class TaskListener(TaskConfig):
             except:
                 pass
             self._alldebrid_magnet_id = 0
+
+        torbox_torrent_id = getattr(self, "_torbox_torrent_id", 0) or 0
+        torbox_web_id = getattr(self, "_torbox_web_id", 0) or 0
+
+        if torbox_torrent_id or torbox_web_id:
+            try:
+                from ..mirror_leech_utils.download_utils.torbox_resolver import (
+                    delete_torrent,
+                    delete_web_download,
+                )
+
+                if torbox_torrent_id:
+                    await delete_torrent(torbox_torrent_id)
+
+                if torbox_web_id:
+                    await delete_web_download(torbox_web_id)
+
+            except:
+                pass
+
+        self._torbox_torrent_id = 0
+        self._torbox_web_id = 0
         msg = f"{self.tag} Download: {escape(str(error))}"
         await send_message(self.message, msg, button)
         if count == 0:

--- a/bot/helper/mirror_leech_utils/download_utils/torbox_resolver.py
+++ b/bot/helper/mirror_leech_utils/download_utils/torbox_resolver.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import asyncio
+from os import path as ospath
+from typing import Any, Awaitable, Callable
+
+from httpx import AsyncClient, HTTPError
+
+from bot import LOGGER
+from bot.core.config_manager import Config
+from bot.helper.ext_utils.exceptions import DirectDownloadLinkException
+
+_API_BASE = "https://api.torbox.app/v1/api"
+_TIMEOUT = 45.0
+_POLL_INTERVAL = 5.0
+_MAX_WAIT = 7200.0
+_NO_SEED_WAIT = 180.0
+_UNLOCK_CONCURRENCY = 3
+
+_READY_STATES = {"cached", "completed", "uploading"}
+_ERROR_STATES = {
+    "error",
+    "failed",
+    "missingfiles",
+    "stalled",
+    "stalled (no seeds)",
+    "dead",
+    "unknown",
+}
+
+
+def _token() -> str:
+    token = (getattr(Config, "TORBOX_API_KEY", "") or "").strip()
+    if not token:
+        raise DirectDownloadLinkException("ERROR: TORBOX_API_KEY is not configured")
+    return token
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_token()}",
+        "User-Agent": "mltb-torbox/1.0",
+    }
+
+
+def _err(payload: Any) -> str:
+    if isinstance(payload, dict):
+        return str(
+            payload.get("detail")
+            or payload.get("message")
+            or payload.get("error")
+            or payload
+        )
+    return str(payload)
+
+
+async def _api(
+    method: str,
+    endpoint: str,
+    *,
+    params: dict[str, Any] | None = None,
+    data: Any = None,
+    files: Any = None,
+) -> Any:
+    try:
+        async with AsyncClient(timeout=_TIMEOUT, headers=_headers()) as client:
+            res = await client.request(
+                method,
+                f"{_API_BASE}{endpoint}",
+                params=params or {},
+                data=data,
+                files=files,
+            )
+            res.raise_for_status()
+            payload = res.json()
+    except HTTPError as exc:
+        raise DirectDownloadLinkException(f"ERROR: TorBox network error: {exc}") from exc
+    except ValueError as exc:
+        raise DirectDownloadLinkException(f"ERROR: TorBox returned malformed JSON: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise DirectDownloadLinkException("ERROR: TorBox returned unexpected payload")
+
+    if payload.get("success") is not True:
+        raise DirectDownloadLinkException(f"ERROR: TorBox: {_err(payload)}")
+
+    return payload.get("data")
+
+
+def _first_item(data: Any) -> dict[str, Any]:
+    if isinstance(data, list):
+        return data[0] if data else {}
+
+    if isinstance(data, dict):
+        for key in ("torrent", "webdl", "download", "item"):
+            if isinstance(data.get(key), dict):
+                return data[key]
+        return data
+
+    return {}
+
+
+def _is_ready(item: dict[str, Any]) -> bool:
+    if item.get("download_finished") is True or item.get("download_present") is True:
+        return True
+
+    state = str(item.get("download_state") or "").lower()
+    return state in _READY_STATES and bool(item.get("files"))
+
+
+def _has_error(item: dict[str, Any]) -> str:
+    if item.get("error"):
+        return str(item["error"])
+
+    state = str(item.get("download_state") or "").lower()
+    if state in _ERROR_STATES:
+        return state
+
+    return ""
+
+
+def _basename(name: str) -> str:
+    return ospath.basename(str(name).rstrip("/")) or "file"
+
+
+async def _create_torrent_from_magnet(magnet: str) -> dict[str, Any]:
+    LOGGER.info("TorBox: creating torrent from magnet")
+    files = {
+        "magnet": (None, magnet),
+        "seed": (None, "3"),
+        "allow_zip": (None, "true"),
+    }
+    data = await _api("POST", "/torrents/createtorrent", files=files)
+    item = _first_item(data)
+    if not item:
+        raise DirectDownloadLinkException("ERROR: TorBox returned no torrent data")
+    return item
+
+
+async def _create_torrent_from_file(torrent_bytes: bytes, filename: str) -> dict[str, Any]:
+    LOGGER.info(f"TorBox: creating torrent from file: {filename}")
+    files = {
+        "file": (filename, torrent_bytes, "application/x-bittorrent"),
+        "seed": (None, "3"),
+        "allow_zip": (None, "true"),
+    }
+    data = await _api("POST", "/torrents/createtorrent", files=files)
+    item = _first_item(data)
+    if not item:
+        raise DirectDownloadLinkException("ERROR: TorBox returned no torrent data")
+    return item
+
+
+async def _create_webdl(link: str) -> dict[str, Any]:
+    LOGGER.info("TorBox: creating web download")
+    files = {"link": (None, link)}
+    data = await _api("POST", "/webdl/createwebdownload", files=files)
+    item = _first_item(data)
+    if not item:
+        raise DirectDownloadLinkException("ERROR: TorBox returned no webdl data")
+    return item
+
+
+async def _get_torrent(torrent_id: int | str) -> dict[str, Any]:
+    data = await _api(
+        "GET",
+        "/torrents/mylist",
+        params={"id": str(torrent_id), "bypass_cache": "true"},
+    )
+    item = _first_item(data)
+    if not item:
+        raise DirectDownloadLinkException(f"ERROR: TorBox returned no torrent status for {torrent_id}")
+    return item
+
+
+async def _get_webdl(web_id: int | str) -> dict[str, Any]:
+    data = await _api(
+        "GET",
+        "/webdl/mylist",
+        params={"id": str(web_id), "bypass_cache": "true"},
+    )
+    item = _first_item(data)
+    if not item:
+        raise DirectDownloadLinkException(f"ERROR: TorBox returned no webdl status for {web_id}")
+    return item
+
+
+async def delete_torrent(torrent_id: int | str) -> bool:
+    try:
+        await _api(
+            "POST",
+            "/torrents/controltorrent",
+            data={"torrent_id": str(torrent_id), "operation": "Delete"},
+        )
+        return True
+    except Exception as exc:
+        LOGGER.warning(f"TorBox: failed to delete torrent {torrent_id}: {exc}")
+        return False
+
+
+async def delete_web_download(web_id: int | str) -> bool:
+    try:
+        await _api(
+            "POST",
+            "/webdl/controlwebdownload",
+            data={"web_id": str(web_id), "operation": "Delete"},
+        )
+        return True
+    except Exception as exc:
+        LOGGER.warning(f"TorBox: failed to delete webdl {web_id}: {exc}")
+        return False
+
+
+async def _wait_ready(
+    item_id: int | str,
+    kind: str,
+    *,
+    is_cancelled: Callable[[], bool] | None = None,
+    progress_callback: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+) -> dict[str, Any]:
+    getter = _get_torrent if kind == "torrent" else _get_webdl
+
+    loop = asyncio.get_event_loop()
+    started = loop.time()
+    no_seed_started = 0.0
+
+    while True:
+        if is_cancelled and is_cancelled():
+            raise DirectDownloadLinkException("ERROR: TorBox task cancelled")
+
+        item = await getter(item_id)
+
+        if progress_callback:
+            await progress_callback(
+                {
+                    "phase": kind,
+                    "name": item.get("name"),
+                    "state": item.get("download_state"),
+                    "progress": item.get("progress"),
+                    "seeds": item.get("seeds"),
+                    "peers": item.get("peers"),
+                    "eta": item.get("eta"),
+                }
+            )
+
+        if _is_ready(item):
+            return item
+
+        err = _has_error(item)
+        if err:
+            raise DirectDownloadLinkException(f"ERROR: TorBox {kind} failed: {err}")
+
+        now = loop.time()
+
+        if kind == "torrent":
+            seeds = int(item.get("seeds") or 0)
+            peers = int(item.get("peers") or 0)
+
+            if seeds == 0 and peers == 0:
+                if no_seed_started == 0:
+                    no_seed_started = now
+                elif now - no_seed_started >= _NO_SEED_WAIT:
+                    raise DirectDownloadLinkException("ERROR: TorBox no seed / no peer timeout")
+            else:
+                no_seed_started = 0.0
+
+        if now - started >= _MAX_WAIT:
+            raise DirectDownloadLinkException("ERROR: TorBox max wait timeout")
+
+        await asyncio.sleep(_POLL_INTERVAL)
+
+
+async def _request_file_link(kind: str, item_id: int | str, file_id: int | str) -> str:
+    endpoint = "/torrents/requestdl" if kind == "torrent" else "/webdl/requestdl"
+    id_key = "torrent_id" if kind == "torrent" else "web_id"
+
+    params = {
+        "token": _token(),
+        id_key: str(item_id),
+        "file_id": str(file_id),
+    }
+
+    last_exc = None
+
+    for attempt in range(1, 4):
+        try:
+            data = await _api("GET", endpoint, params=params)
+            if isinstance(data, str) and data:
+                return data
+            raise DirectDownloadLinkException("ERROR: TorBox did not return direct URL")
+        except Exception as exc:
+            last_exc = exc
+            if attempt < 3:
+                await asyncio.sleep(attempt * 2)
+                continue
+            raise
+
+    raise DirectDownloadLinkException(f"ERROR: TorBox requestdl failed: {last_exc}")
+
+
+async def _payload(item: dict[str, Any], kind: str, item_id: int | str) -> dict[str, Any]:
+    files = item.get("files") or []
+
+    if not isinstance(files, list) or not files:
+        raise DirectDownloadLinkException("ERROR: TorBox returned no files")
+
+    semaphore = asyncio.Semaphore(_UNLOCK_CONCURRENCY)
+    contents: list[dict[str, Any]] = []
+
+    async def one(file_item: dict[str, Any]):
+        file_id = file_item.get("id")
+        if file_id is None:
+            return
+
+        async with semaphore:
+            direct = await _request_file_link(kind, item_id, file_id)
+
+        full_name = file_item.get("name") or file_item.get("short_name") or "file"
+
+        contents.append(
+            {
+                "filename": file_item.get("short_name") or _basename(full_name),
+                "path": full_name,
+                "url": direct,
+                "size": int(file_item.get("size") or 0),
+                "headers": {},
+            }
+        )
+
+    await asyncio.gather(*(one(f) for f in files if isinstance(f, dict)))
+
+    if not contents:
+        raise DirectDownloadLinkException("ERROR: TorBox could not create direct links")
+
+    return {
+        "title": item.get("name") or "TorBox",
+        "total_size": sum(x["size"] for x in contents),
+        "contents": contents,
+    }
+
+
+async def torbox_resolve_magnet(
+    magnet: str,
+    *,
+    is_cancelled: Callable[[], bool] | None = None,
+    progress_callback: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+) -> dict[str, Any]:
+    entry = await _create_torrent_from_magnet(magnet)
+    torrent_id = entry.get("torrent_id") or entry.get("id")
+
+    if not torrent_id:
+        raise DirectDownloadLinkException("ERROR: TorBox did not return torrent_id")
+
+    try:
+        item = await _wait_ready(
+            torrent_id,
+            "torrent",
+            is_cancelled=is_cancelled,
+            progress_callback=progress_callback,
+        )
+        result = await _payload(item, "torrent", torrent_id)
+        result["torbox_torrent_id"] = torrent_id
+        return result
+    except Exception:
+        await delete_torrent(torrent_id)
+        raise
+
+
+async def torbox_resolve_torrent(
+    torrent_bytes: bytes,
+    filename: str,
+    *,
+    is_cancelled: Callable[[], bool] | None = None,
+    progress_callback: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+) -> dict[str, Any]:
+    entry = await _create_torrent_from_file(torrent_bytes, filename)
+    torrent_id = entry.get("torrent_id") or entry.get("id")
+
+    if not torrent_id:
+        raise DirectDownloadLinkException("ERROR: TorBox did not return torrent_id")
+
+    try:
+        item = await _wait_ready(
+            torrent_id,
+            "torrent",
+            is_cancelled=is_cancelled,
+            progress_callback=progress_callback,
+        )
+        result = await _payload(item, "torrent", torrent_id)
+        result["torbox_torrent_id"] = torrent_id
+        return result
+    except Exception:
+        await delete_torrent(torrent_id)
+        raise
+
+
+async def torbox_resolve(
+    link: str,
+    *,
+    is_cancelled: Callable[[], bool] | None = None,
+    progress_callback: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+) -> dict[str, Any]:
+    entry = await _create_webdl(link)
+    web_id = entry.get("webdownload_id") or entry.get("web_id") or entry.get("id")
+
+    if not web_id:
+        raise DirectDownloadLinkException("ERROR: TorBox did not return webdownload_id")
+
+    try:
+        item = await _wait_ready(
+            web_id,
+            "webdl",
+            is_cancelled=is_cancelled,
+            progress_callback=progress_callback,
+        )
+        result = await _payload(item, "webdl", web_id)
+        result["torbox_web_id"] = web_id
+        return result
+    except Exception:
+        await delete_web_download(web_id)
+        raise

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -1,5 +1,7 @@
 from aiofiles import open as aiopen
 from aiofiles.os import path as aiopath
+from aiofiles import open as aiopen
+from os import path as ospath
 from base64 import b64encode
 from os.path import basename as ospath_basename
 from re import match as re_match
@@ -28,6 +30,11 @@ from ..helper.mirror_leech_utils.download_utils.alldebrid_resolver import (
     alldebrid_resolve,
     alldebrid_resolve_magnet,
     alldebrid_resolve_torrent,
+)
+from ..helper.mirror_leech_utils.download_utils.torbox_resolver import (
+    torbox_resolve,
+    torbox_resolve_magnet,
+    torbox_resolve_torrent,
 )
 from ..helper.mirror_leech_utils.download_utils.direct_downloader import (
     add_direct_download,
@@ -100,6 +107,7 @@ class Mirror(TaskListener):
             "-bt": False,
             "-ut": False,
             "-ad": False,
+            "-tb": False,
             "-i": 0,
             "-sp": 0,
             "link": "",
@@ -147,6 +155,7 @@ class Mirror(TaskListener):
         self.bot_trans = args["-bt"]
         self.user_trans = args["-ut"]
         self.is_alldebrid = args["-ad"]
+        self.is_torbox = args["-tb"]
         self.ffmpeg_cmds = args["-ff"]
 
         headers = args["-h"]
@@ -311,6 +320,44 @@ class Mirror(TaskListener):
             await self.remove_from_same_dir()
             return
 
+        if self.is_torbox:
+            try:
+                if is_magnet(self.link):
+                    resolved = await torbox_resolve_magnet(
+                        self.link,
+                        is_cancelled=lambda: self.is_cancelled,
+                    )
+                    self._torbox_torrent_id = resolved.get("torbox_torrent_id", 0)
+                    self.link = resolved
+
+                elif (
+                    isinstance(self.link, str)
+                    and self.link.endswith(".torrent")
+                    and await aiopath.exists(self.link)
+                ):
+                    async with aiopen(self.link, "rb") as f:
+                        torrent_bytes = await f.read()
+
+                    resolved = await torbox_resolve_torrent(
+                        torrent_bytes,
+                        ospath.basename(self.link),
+                        is_cancelled=lambda: self.is_cancelled,
+                    )
+                    self._torbox_torrent_id = resolved.get("torbox_torrent_id", 0)
+                    self.link = resolved
+
+            except DirectDownloadLinkException as e:
+                msg = str(e)
+                LOGGER.info(msg)
+                if msg.startswith("ERROR:"):
+                    await send_message(self.message, msg)
+                await self.remove_from_same_dir()
+                return
+            except Exception as e:
+                await send_message(self.message, e)
+                await self.remove_from_same_dir()
+                return
+
         if self.is_alldebrid and (
             is_magnet(self.link) or self.link.endswith(".torrent")
         ):
@@ -349,7 +396,40 @@ class Mirror(TaskListener):
                 self.is_qbit = False
 
         if (
-            not self.is_jd
+            self.is_torbox
+            and isinstance(self.link, str)
+            and not self.is_jd
+            and not self.is_nzb
+            and not self.is_qbit
+            and not is_magnet(self.link)
+            and not is_rclone_path(self.link)
+            and not is_gdrive_link(self.link)
+            and not self.link.endswith(".torrent")
+            and file_ is None
+            and not is_gdrive_id(self.link)
+        ):
+            try:
+                resolved = await torbox_resolve(
+                    self.link,
+                    is_cancelled=lambda: self.is_cancelled,
+                )
+                self._torbox_web_id = resolved.get("torbox_web_id", 0)
+                self.link = resolved
+            except DirectDownloadLinkException as e:
+                msg = str(e)
+                LOGGER.info(msg)
+                if msg.startswith("ERROR:"):
+                    await send_message(self.message, msg)
+                await self.remove_from_same_dir()
+                return
+            except Exception as e:
+                await send_message(self.message, e)
+                await self.remove_from_same_dir()
+                return
+
+        if (
+            isinstance(self.link, str)
+            and not self.is_jd
             and not self.is_nzb
             and not self.is_qbit
             and not is_magnet(self.link)


### PR DESCRIPTION
## Summary

This PR adds TorBox integration with a new `-tb` flag.

The new flag works similarly to the existing AllDebrid `-ad` flow, but routes supported inputs through TorBox instead. It supports:

- Magnet URIs
- Replied `.torrent` files
- Regular web/filehost links via TorBox WebDL

For magnet and torrent inputs, the bot uploads the item to TorBox, polls until the download is ready, requests direct file links from TorBox, and then hands the resulting multi-file payload to the existing direct download pipeline.

This follows the same integration pattern already used for the AllDebrid `-ad` feature, where debrid-resolved payloads are passed into the existing `add_direct_download` flow. The previous AllDebrid commits added `-ad` to config, argument parsing, help text, and mirror routing, and this PR extends that same structure for TorBox.


https://github.com/anasty17/mirror-leech-telegram-bot/pull/1928/changes