### PR TITLE
Add direct upload support for multiple host

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -14,6 +14,13 @@ class Config:
     BASE_URL_PORT = 80
     BOT_TOKEN = ""
     BUZZHEAVIER_ACCOUNT_ID = ""
+    CATBOX_USER_HASH = ""
+    LITTERBOX_TIME = "1h"
+    PIXELDRAIN_API_KEY = ""
+    VIKINGFILE_USER_HASH = ""
+    IMGUR_CLIENT_ID = ""
+    IMGCHEST_API_KEY = ""
+    IMGBB_API_KEY = ""
     GOFILE_API_KEY = ""
     CMD_SUFFIX = ""
     CLONE_DUMP_CHATS = ""
@@ -157,7 +164,7 @@ class Config:
         if isinstance(converted_value, str):
             converted_value = converted_value.strip()
 
-        if attr == "DEFAULT_UPLOAD" and converted_value not in {"gd", "bh", "gf"}:
+        if attr == "DEFAULT_UPLOAD" and converted_value not in {"gd", "bh", "gf", "cb", "lb", "pd", "vf", "imgur", "ic", "ibb"}:
             return "rc"
 
         if attr in {

--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -21,6 +21,7 @@ class Config:
     IMGUR_CLIENT_ID = ""
     IMGCHEST_API_KEY = ""
     IMGBB_API_KEY = ""
+    KRAKENFILES_API_KEY = ""
     GOFILE_API_KEY = ""
     CMD_SUFFIX = ""
     CLONE_DUMP_CHATS = ""

--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -165,7 +165,7 @@ class Config:
         if isinstance(converted_value, str):
             converted_value = converted_value.strip()
 
-        if attr == "DEFAULT_UPLOAD" and converted_value not in {"gd", "bh", "gf", "cb", "lb", "pd", "vf", "imgur", "ic", "ibb"}:
+        if attr == "DEFAULT_UPLOAD" and converted_value not in {"gd", "bh", "gf", "cb", "lb", "pd", "vf", "imgur", "ic", "ibb", "kf"}:
             return "rc"
 
         if attr in {

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -90,6 +90,7 @@ class TaskConfig:
         self._alldebrid_magnet_id = 0
         self._torbox_torrent_id = 0
         self._torbox_web_id = 0
+        self.direct_upload = None
         self.is_leech = False
         self.is_qbit = False
         self.is_nzb = False
@@ -277,16 +278,20 @@ class TaskConfig:
         default_upload = (
             self.user_dict.get("DEFAULT_UPLOAD", "") or Config.DEFAULT_UPLOAD
         )
+        DIRECT_UPLOADS = {"cb", "lb", "pd", "vf", "imgur", "ic", "ibb"}
+        
         if default_upload == "bh" or self.up_dest == "bh":
             self.is_buzzheavier = True
         elif default_upload == "gf" or self.up_dest == "gf":
             self.is_gofile = True
+        elif default_upload in DIRECT_UPLOADS or self.up_dest in DIRECT_UPLOADS:
+            self.direct_upload = self.up_dest or default_upload
 
         self.files_links = self.user_dict.get("FILES_LINKS", False) or (
             Config.FILES_LINKS if "FILES_LINKS" not in self.user_dict else False
         )
 
-        if not self.is_leech and not self.is_buzzheavier and not self.is_gofile:
+        if not self.is_leech and not self.is_buzzheavier and not self.is_gofile and not self.direct_upload:
             self.stop_duplicate = (
                 self.user_dict.get("STOP_DUPLICATE")
                 or "STOP_DUPLICATE" not in self.user_dict
@@ -351,7 +356,7 @@ class TaskConfig:
                     self.link
                 ) != self.get_config_path(self.up_dest):
                     raise ValueError("You must use the same config to clone!")
-        elif not self.is_buzzheavier and not self.is_gofile:
+        elif not self.is_buzzheavier and not self.is_gofile and not self.direct_upload:
             self.up_dest = (
                 self.up_dest
                 or self.user_dict.get("LEECH_DUMP_CHAT")

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -278,7 +278,7 @@ class TaskConfig:
         default_upload = (
             self.user_dict.get("DEFAULT_UPLOAD", "") or Config.DEFAULT_UPLOAD
         )
-        DIRECT_UPLOADS = {"cb", "lb", "pd", "vf", "imgur", "ic", "ibb"}
+        DIRECT_UPLOADS = {"cb", "lb", "pd", "vf", "imgur", "ic", "ibb", "kf"}
         
         if default_upload == "bh" or self.up_dest == "bh":
             self.is_buzzheavier = True

--- a/bot/helper/ext_utils/help_messages.py
+++ b/bot/helper/ext_utils/help_messages.py
@@ -96,13 +96,14 @@ Note: Only mb and gb are supported or write in bytes without unit!"""
 
 upload = """<b>Upload Destination</b>: -up
 
-/cmd link -up rc/gd/rcl/gdl/bh/gf (rcl: to select rclone config, remote & path | gdl: To select token.pickle, gdrive id | gf: upload to GoFile) using buttons
+/cmd link -up rc/gd/rcl/gdl/bh/gf/cb/lb/pd/vf/imgur/ic/ibb (rcl: to select rclone config, remote & path | gdl: To select token.pickle, gdrive id | gf: upload to GoFile) using buttons
 You can directly add the upload path: -up remote:dir/subdir or -up Gdrive_id or -up id/username (telegram) or -up id/username|topic_id (telegram)
 If DEFAULT_UPLOAD is `rc` then you can pass up: `gd` to upload using gdrive tools to GDRIVE_ID.
 If DEFAULT_UPLOAD is `gd` then you can pass up: `rc` to upload to RCLONE_PATH.
 If DEFAULT_UPLOAD is `bh` or `gf` then you can pass up: `rc` to upload to RCLONE_PATH.
 If DEFAULT_UPLOAD is `gd` then you can pass up: `bh` to upload to BUZZHEAVIER or `gf` to upload to GoFile.
 GoFile uses GOFILE_API_KEY when configured; otherwise guest upload is used.
+cb: Catbox / lb: Litterbox temporary upload / pd: PixelDrain / vf: VikingFile / imgur: Imgur image upload / ic: ImgChest image upload / ibb: ImgBB image upload
 
 If you want to add path or gdrive manually from your config/token (UPLOADED FROM USETTING) add mrcc: for rclone and mtp: before the path/gdrive_id without space.
 /cmd link -up mrcc:main:dump or -up mtp:gdrive_id <strong>OR you can simply edit upload using owner/user|token/config from usetting without adding mtp: or mrcc: before the upload path/id</strong>

--- a/bot/helper/ext_utils/help_messages.py
+++ b/bot/helper/ext_utils/help_messages.py
@@ -96,14 +96,14 @@ Note: Only mb and gb are supported or write in bytes without unit!"""
 
 upload = """<b>Upload Destination</b>: -up
 
-/cmd link -up rc/gd/rcl/gdl/bh/gf/cb/lb/pd/vf/imgur/ic/ibb (rcl: to select rclone config, remote & path | gdl: To select token.pickle, gdrive id | gf: upload to GoFile) using buttons
+/cmd link -up rc/gd/rcl/gdl/bh/gf/cb/lb/pd/vf/imgur/ic/ibb/kf (rcl: to select rclone config, remote & path | gdl: To select token.pickle, gdrive id | gf: upload to GoFile) using buttons
 You can directly add the upload path: -up remote:dir/subdir or -up Gdrive_id or -up id/username (telegram) or -up id/username|topic_id (telegram)
 If DEFAULT_UPLOAD is `rc` then you can pass up: `gd` to upload using gdrive tools to GDRIVE_ID.
 If DEFAULT_UPLOAD is `gd` then you can pass up: `rc` to upload to RCLONE_PATH.
 If DEFAULT_UPLOAD is `bh` or `gf` then you can pass up: `rc` to upload to RCLONE_PATH.
 If DEFAULT_UPLOAD is `gd` then you can pass up: `bh` to upload to BUZZHEAVIER or `gf` to upload to GoFile.
 GoFile uses GOFILE_API_KEY when configured; otherwise guest upload is used.
-cb: Catbox / lb: Litterbox temporary upload / pd: PixelDrain / vf: VikingFile / imgur: Imgur image upload / ic: ImgChest image upload / ibb: ImgBB image upload
+cb: Catbox / lb: Litterbox temporary upload / pd: PixelDrain / vf: VikingFile / imgur: Imgur image upload / ic: ImgChest image upload / ibb: ImgBB image upload / kf: KrakenFiles
 
 If you want to add path or gdrive manually from your config/token (UPLOADED FROM USETTING) add mrcc: for rclone and mtp: before the path/gdrive_id without space.
 /cmd link -up mrcc:main:dump or -up mtp:gdrive_id <strong>OR you can simply edit upload using owner/user|token/config from usetting without adding mtp: or mrcc: before the upload path/id</strong>

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -38,12 +38,14 @@ from ..mirror_leech_utils.gdrive_utils.upload import GoogleDriveUpload
 from ..mirror_leech_utils.rclone_utils.transfer import RcloneTransferHelper
 from ..mirror_leech_utils.buzzheavier_uploader import BuzzHeavierUploader
 from ..mirror_leech_utils.gofile_uploader import GoFileUploader
+from ..mirror_leech_utils.host_uploader import HostUploader
 from ..mirror_leech_utils.status_utils.gdrive_status import GoogleDriveStatus
 from ..mirror_leech_utils.status_utils.queue_status import QueueStatus
 from ..mirror_leech_utils.status_utils.rclone_status import RcloneStatus
 from ..mirror_leech_utils.status_utils.telegram_status import TelegramStatus
 from ..mirror_leech_utils.status_utils.buzzheavier_status import BuzzHeavierStatus
 from ..mirror_leech_utils.status_utils.gofile_status import GoFileStatus
+from ..mirror_leech_utils.status_utils.host_status import HostUploadStatus
 from ..mirror_leech_utils.telegram_uploader import TelegramUploader
 from ..telegram_helper.button_build import ButtonMaker
 from ..telegram_helper.message_utils import (
@@ -325,6 +327,16 @@ class TaskListener(TaskConfig):
                 gf.upload(),
             )
             del gf
+        elif self.direct_upload:
+            LOGGER.info(f"{self.direct_upload.upper()} Upload Name: {self.name}")
+            host = HostUploader(self, up_path, self.direct_upload)
+            async with task_dict_lock:
+                task_dict[self.mid] = HostUploadStatus(self, host, gid, "up")
+            await gather(
+                update_status_message(self.message.chat.id),
+                host.upload(),
+            )
+            del host
         elif is_gdrive_id(self.up_dest):
             LOGGER.info(f"Gdrive Upload Name: {self.name}")
             drive = GoogleDriveUpload(self, up_path)
@@ -358,7 +370,7 @@ class TaskListener(TaskConfig):
             await database.rm_complete_task(self.message.link)
         msg = f"<b>Name: </b><code>{escape(self.name)}</code>\n\n<b>Size: </b>{get_readable_file_size(self.size)}"
         LOGGER.info(f"Task Done: {self.name}")
-        if self.is_leech or self.is_buzzheavier:
+        if self.is_leech:
             msg += f"\n<b>Total Files: </b>{folders}"
             if mime_type != 0:
                 msg += f"\n<b>Corrupted Files: </b>{mime_type}"

--- a/bot/helper/mirror_leech_utils/host_uploader.py
+++ b/bot/helper/mirror_leech_utils/host_uploader.py
@@ -1,0 +1,470 @@
+from asyncio import CancelledError
+from base64 import b64encode
+from logging import getLogger
+from os import path as ospath, walk
+from time import time
+from urllib.parse import quote
+from uuid import uuid4
+
+from aiofiles import open as aiopen
+from aiofiles.os import path as aiopath
+from httpx import AsyncByteStream, AsyncClient, HTTPError, Limits, Timeout
+
+from ...core.config_manager import Config
+from ..ext_utils.bot_utils import sync_to_async
+
+LOGGER = getLogger(__name__)
+
+_UPLOAD_CHUNK = 1024 * 1024
+_HTTP_TIMEOUT = Timeout(connect=30.0, read=600.0, write=600.0, pool=30.0)
+
+IMAGE_HOSTS = {"imgur", "ic", "ibb"}
+IMAGE_EXTS = {
+    ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tif", ".tiff"
+}
+
+
+class MultipartFileStream(AsyncByteStream):
+    def __init__(
+        self,
+        uploader,
+        file_path,
+        file_size,
+        fields,
+        file_field,
+        content_type="application/octet-stream",
+    ):
+        self._uploader = uploader
+        self._file_path = file_path
+        self._file_size = file_size
+        self.boundary = f"----mltb-host-{uuid4().hex}"
+
+        file_name = ospath.basename(file_path).replace('"', "")
+
+        parts = []
+        for key, value in fields.items():
+            if value is None:
+                continue
+            parts.append(
+                f"--{self.boundary}\r\n"
+                f'Content-Disposition: form-data; name="{key}"\r\n\r\n'
+                f"{value}\r\n"
+            )
+
+        parts.append(
+            f"--{self.boundary}\r\n"
+            f'Content-Disposition: form-data; name="{file_field}"; filename="{file_name}"\r\n'
+            f"Content-Type: {content_type}\r\n\r\n"
+        )
+
+        self._prefix = "".join(parts).encode()
+        self._suffix = f"\r\n--{self.boundary}--\r\n".encode()
+        self.content_length = len(self._prefix) + self._file_size + len(self._suffix)
+
+    async def __aiter__(self):
+        yield self._prefix
+
+        async with aiopen(self._file_path, "rb") as fh:
+            while True:
+                if self._uploader._listener.is_cancelled:
+                    raise CancelledError()
+
+                chunk = await fh.read(_UPLOAD_CHUNK)
+                if not chunk:
+                    break
+
+                self._uploader._processed_bytes += len(chunk)
+                yield chunk
+
+        yield self._suffix
+
+
+class RawFileStream(AsyncByteStream):
+    def __init__(self, uploader, file_path):
+        self._uploader = uploader
+        self._file_path = file_path
+
+    async def __aiter__(self):
+        async with aiopen(self._file_path, "rb") as fh:
+            while True:
+                if self._uploader._listener.is_cancelled:
+                    raise CancelledError()
+
+                chunk = await fh.read(_UPLOAD_CHUNK)
+                if not chunk:
+                    break
+
+                self._uploader._processed_bytes += len(chunk)
+                yield chunk
+
+
+class HostUploader:
+    def __init__(self, listener, path, host):
+        self._listener = listener
+        self._path = path
+        self._host = host
+        self._processed_bytes = 0
+        self._start_time = time()
+
+    @property
+    def host_name(self):
+        return self._host
+
+    @property
+    def processed_bytes(self):
+        return self._processed_bytes
+
+    @property
+    def speed(self):
+        try:
+            return self._processed_bytes / (time() - self._start_time)
+        except Exception:
+            return 0
+
+    async def _post_multipart(
+        self,
+        client,
+        url,
+        file_path,
+        fields,
+        file_field,
+        headers=None,
+        json_response=True,
+    ):
+        file_size = await aiopath.getsize(file_path)
+        stream = MultipartFileStream(self, file_path, file_size, fields, file_field)
+
+        req_headers = {
+            "Content-Type": f"multipart/form-data; boundary={stream.boundary}",
+            "Content-Length": str(stream.content_length),
+        }
+
+        if headers:
+            req_headers.update(headers)
+
+        response = await client.post(url, content=stream, headers=req_headers)
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"{self._host} upload failed [{response.status_code}]: "
+                f"{response.text[:300]}"
+            )
+
+        if not json_response:
+            text = response.text.strip()
+            if not text:
+                raise RuntimeError(f"{self._host} returned empty response")
+            return text
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"{self._host} returned non-JSON response: {response.text[:300]}"
+            ) from exc
+
+    async def _upload_catbox(self, client, file_path):
+        size = await aiopath.getsize(file_path)
+        if size > 200 * 1024 * 1024:
+            raise RuntimeError("Catbox limit is 200 MB per file")
+
+        fields = {
+            "reqtype": "fileupload",
+            "userhash": (Config.CATBOX_USER_HASH or "").strip() or None,
+        }
+
+        link = await self._post_multipart(
+            client,
+            "https://catbox.moe/user/api.php",
+            file_path,
+            fields,
+            "fileToUpload",
+            json_response=False,
+        )
+
+        if not link.startswith("http"):
+            raise RuntimeError(f"Catbox bad response: {link[:300]}")
+
+        return link
+
+    async def _upload_litterbox(self, client, file_path):
+        expiry = (Config.LITTERBOX_TIME or "1h").strip()
+        if expiry not in {"1h", "12h", "24h", "72h"}:
+            expiry = "1h"
+
+        fields = {
+            "reqtype": "fileupload",
+            "time": expiry,
+        }
+
+        link = await self._post_multipart(
+            client,
+            "https://litterbox.catbox.moe/resources/internals/api.php",
+            file_path,
+            fields,
+            "fileToUpload",
+            json_response=False,
+        )
+
+        if not link.startswith("http"):
+            raise RuntimeError(f"Litterbox bad response: {link[:300]}")
+
+        return link
+
+    async def _upload_pixeldrain(self, client, file_path):
+        api_key = (Config.PIXELDRAIN_API_KEY or "").strip()
+        if not api_key:
+            raise RuntimeError("PIXELDRAIN_API_KEY is required")
+
+        file_name = quote(ospath.basename(file_path), safe="")
+        file_size = await aiopath.getsize(file_path)
+
+        credentials = b64encode(f":{api_key}".encode()).decode()
+
+        headers = {
+            "Authorization": f"Basic {credentials}",
+            "Content-Type": "application/octet-stream",
+            "Content-Length": str(file_size),
+        }
+
+        response = await client.put(
+            f"https://pixeldrain.com/api/file/{file_name}",
+            content=RawFileStream(self, file_path),
+            headers=headers,
+        )
+
+        if response.status_code not in {200, 201}:
+            raise RuntimeError(
+                f"PixelDrain upload failed [{response.status_code}]: "
+                f"{response.text[:300]}"
+            )
+
+        payload = response.json()
+        file_id = payload.get("id")
+
+        if not file_id:
+            raise RuntimeError(f"PixelDrain response missing id: {payload}")
+
+        return f"https://pixeldrain.com/u/{file_id}"
+
+    async def _upload_vikingfile(self, client, file_path):
+        server_resp = await client.get("https://vikingfile.com/api/get-server")
+        if server_resp.status_code >= 400:
+            raise RuntimeError(
+                f"VikingFile server lookup failed: {server_resp.text[:300]}"
+            )
+
+        server = server_resp.json().get("server")
+        if not server:
+            raise RuntimeError("VikingFile response missing server")
+
+        fields = {
+            "user": (Config.VIKINGFILE_USER_HASH or "").strip(),
+        }
+
+        payload = await self._post_multipart(
+            client,
+            server,
+            file_path,
+            fields,
+            "file",
+            json_response=True,
+        )
+
+        link = payload.get("url")
+        if not link:
+            raise RuntimeError(f"VikingFile response missing url: {payload}")
+
+        return link
+
+    async def _upload_imgur(self, client, file_path):
+        client_id = (Config.IMGUR_CLIENT_ID or "").strip()
+        if not client_id:
+            raise RuntimeError("IMGUR_CLIENT_ID is required")
+
+        payload = await self._post_multipart(
+            client,
+            "https://api.imgur.com/3/image",
+            file_path,
+            {},
+            "image",
+            headers={"Authorization": f"Client-ID {client_id}"},
+            json_response=True,
+        )
+
+        link = payload.get("data", {}).get("link")
+        if not link:
+            raise RuntimeError(f"Imgur response missing link: {payload}")
+
+        return link
+
+    async def _upload_imgchest(self, client, file_path):
+        token = (Config.IMGCHEST_API_KEY or "").strip()
+        if not token:
+            raise RuntimeError("IMGCHEST_API_KEY is required")
+
+        fields = {
+            "privacy": "hidden",
+        }
+
+        payload = await self._post_multipart(
+            client,
+            "https://api.imgchest.com/v1/post",
+            file_path,
+            fields,
+            "images[]",
+            headers={"Authorization": f"Bearer {token}"},
+            json_response=True,
+        )
+
+        post_id = payload.get("data", {}).get("id")
+        if not post_id:
+            raise RuntimeError(f"ImgChest response missing post id: {payload}")
+
+        return f"https://imgchest.com/p/{post_id}"
+
+    async def _upload_imgbb(self, client, file_path):
+        api_key = (Config.IMGBB_API_KEY or "").strip()
+        if not api_key:
+            raise RuntimeError("IMGBB_API_KEY is required")
+
+        size = await aiopath.getsize(file_path)
+        if size > 32 * 1024 * 1024:
+            raise RuntimeError("ImgBB limit is 32 MB per image")
+
+        payload = await self._post_multipart(
+            client,
+            f"https://api.imgbb.com/1/upload?key={api_key}",
+            file_path,
+            {},
+            "image",
+            json_response=True,
+        )
+
+        data = payload.get("data", {})
+        link = data.get("url_viewer") or data.get("url") or data.get("display_url")
+
+        if not link:
+            raise RuntimeError(f"ImgBB response missing link: {payload}")
+
+        return link
+
+    async def _upload_one(self, client, file_path):
+        if self._listener.is_cancelled:
+            raise CancelledError()
+
+        ext = ospath.splitext(file_path)[1].lower()
+
+        if self._host in IMAGE_HOSTS and ext not in IMAGE_EXTS:
+            raise RuntimeError(
+                f"{self._host} only supports image uploads; skipped: "
+                f"{ospath.basename(file_path)}"
+            )
+
+        if self._host == "cb":
+            return await self._upload_catbox(client, file_path)
+
+        if self._host == "lb":
+            return await self._upload_litterbox(client, file_path)
+
+        if self._host == "pd":
+            return await self._upload_pixeldrain(client, file_path)
+
+        if self._host == "vf":
+            return await self._upload_vikingfile(client, file_path)
+
+        if self._host == "imgur":
+            return await self._upload_imgur(client, file_path)
+
+        if self._host == "ic":
+            return await self._upload_imgchest(client, file_path)
+
+        if self._host == "ibb":
+            return await self._upload_imgbb(client, file_path)
+
+        raise RuntimeError(f"Unknown upload host: {self._host}")
+
+    async def upload(self):
+        files = []
+        corrupted = 0
+        error = ""
+        files_dict = {}
+        first_link = None
+
+        if await aiopath.isfile(self._path):
+            files.append(self._path)
+        else:
+            walk_data = await sync_to_async(lambda: list(walk(self._path)))
+            for root, _, names in walk_data:
+                for name in sorted(names):
+                    candidate = ospath.join(root, name)
+                    if await aiopath.isfile(candidate):
+                        files.append(candidate)
+
+        if not files:
+            await self._listener.on_upload_error(
+                f"{self._host}: no files were found to upload"
+            )
+            return
+
+        total_files = len(files)
+
+        try:
+            async with AsyncClient(
+                timeout=_HTTP_TIMEOUT,
+                limits=Limits(max_connections=4, max_keepalive_connections=2),
+            ) as client:
+                for file_path in files:
+                    try:
+                        LOGGER.info(f"Uploading to {self._host}: {file_path}")
+                        link = await self._upload_one(client, file_path)
+
+                    except (HTTPError, RuntimeError) as exc:
+                        LOGGER.error(
+                            f"{self._host} Upload Error: {exc} - File Path: {file_path}"
+                        )
+                        error = str(exc)
+                        corrupted += 1
+                        continue
+
+                    except CancelledError:
+                        return
+
+                    if self._listener.is_cancelled:
+                        return
+
+                    first_link = first_link or link
+
+                    if self._listener.files_links:
+                        files_dict[link] = ospath.basename(file_path)
+
+        except Exception as exc:
+            LOGGER.error(f"{self._host} session error: {exc}")
+            await self._listener.on_upload_error(f"{self._host}: {exc}")
+            return
+
+        if total_files <= corrupted:
+            await self._listener.on_upload_error(
+                f"Files corrupted or unable to upload. {error or 'Check logs!'}"
+            )
+            return
+
+        if self._listener.is_cancelled:
+            return
+
+        LOGGER.info(
+            f"Uploaded To {self._host}: {self._listener.name} - "
+            f"{total_files - corrupted} files"
+        )
+
+        await self._listener.on_upload_complete(
+            first_link,
+            files_dict,
+            total_files,
+            corrupted,
+        )
+
+    async def cancel_task(self):
+        self._listener.is_cancelled = True
+        LOGGER.info(f"Cancelling Upload: {self._listener.name}")
+        await self._listener.on_upload_error("your upload has been stopped!")

--- a/bot/helper/mirror_leech_utils/host_uploader.py
+++ b/bot/helper/mirror_leech_utils/host_uploader.py
@@ -18,7 +18,7 @@ LOGGER = getLogger(__name__)
 _UPLOAD_CHUNK = 1024 * 1024
 _HTTP_TIMEOUT = Timeout(connect=30.0, read=600.0, write=600.0, pool=30.0)
 
-IMAGE_HOSTS = {"imgur", "ic", "ibb"}
+IMAGE_HOSTS = {"ibb"}
 IMAGE_EXTS = {
     ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tif", ".tiff"
 }

--- a/bot/helper/mirror_leech_utils/host_uploader.py
+++ b/bot/helper/mirror_leech_utils/host_uploader.py
@@ -277,6 +277,72 @@ class HostUploader:
 
         return link
 
+    async def _upload_krakenfiles(self, client, file_path):
+        api_key = (Config.KRAKENFILES_API_KEY or "").strip()
+
+        file_size = await aiopath.getsize(file_path)
+
+        # KrakenFiles anonymous limit: 1 GB
+        # KrakenFiles account/API key limit: 2 GB
+        if api_key:
+            if file_size > 2 * 1024 * 1024 * 1024:
+                raise RuntimeError("KrakenFiles limit is 2 GB with API key")
+        else:
+            if file_size > 1 * 1024 * 1024 * 1024:
+                raise RuntimeError("KrakenFiles anonymous limit is 1 GB")
+
+        headers = {
+            "Accept": "application/json",
+        }
+
+        if api_key:
+            headers["X-AUTH-TOKEN"] = api_key
+
+        server_response = await client.get(
+            "https://krakenfiles.com/api/server/available",
+            headers={"Accept": "application/json"},
+        )
+
+        if server_response.status_code >= 400:
+            raise RuntimeError(
+                f"KrakenFiles server lookup failed [{server_response.status_code}]: "
+                f"{server_response.text[:300]}"
+            )
+
+        try:
+            server_payload = server_response.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"KrakenFiles returned non-JSON server response: "
+                f"{server_response.text[:300]}"
+            ) from exc
+
+        data = server_payload.get("data", {})
+        upload_url = data.get("url")
+        server_access_token = data.get("serverAccessToken")
+
+        if not upload_url or not server_access_token:
+            raise RuntimeError(f"KrakenFiles server response missing data: {server_payload}")
+
+        payload = await self._post_multipart(
+            client,
+            upload_url,
+            file_path,
+            {
+                "serverAccessToken": server_access_token,
+            },
+            "file",
+            headers=headers,
+            json_response=True,
+        )
+
+        link = payload.get("data", {}).get("url")
+
+        if not link:
+            raise RuntimeError(f"KrakenFiles response missing url: {payload}")
+
+        return link
+
     async def _upload_imgur(self, client, file_path):
         client_id = (Config.IMGUR_CLIENT_ID or "").strip()
         if not client_id:

--- a/bot/helper/mirror_leech_utils/status_utils/host_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/host_status.py
@@ -1,0 +1,50 @@
+from ...ext_utils.status_utils import (
+    MirrorStatus,
+    get_readable_file_size,
+    get_readable_time,
+)
+
+
+class HostUploadStatus:
+    def __init__(self, listener, obj, gid, status):
+        self.listener = listener
+        self._obj = obj
+        self._size = self.listener.size
+        self._gid = gid
+        self._status = status
+        self.tool = obj.host_name
+
+    def processed_bytes(self):
+        return get_readable_file_size(self._obj.processed_bytes)
+
+    def size(self):
+        return get_readable_file_size(self._size)
+
+    def status(self):
+        return MirrorStatus.STATUS_UPLOAD
+
+    def name(self):
+        return self.listener.name
+
+    def progress(self):
+        try:
+            progress_raw = self._obj.processed_bytes / self._size * 100
+        except Exception:
+            progress_raw = 0
+        return f"{round(progress_raw, 2)}%"
+
+    def speed(self):
+        return f"{get_readable_file_size(self._obj.speed)}/s"
+
+    def eta(self):
+        try:
+            seconds = (self._size - self._obj.processed_bytes) / self._obj.speed
+            return get_readable_time(seconds)
+        except Exception:
+            return "-"
+
+    def gid(self):
+        return self._gid
+
+    def task(self):
+        return self._obj


### PR DESCRIPTION
## Summary

- Added direct upload support for Catbox, Litterbox, PixelDrain, VikingFile, Imgur, ImgChest, ImgBB and Krakenfiles.
- Added `host_uploader.py` for multi-host uploads.
- Added upload status support for host uploads.
- Added new `-up` options:
  - `cb` for Catbox
  - `lb` for Litterbox
  - `pd` for PixelDrain
  - `vf` for VikingFile
  - `imgur` for Imgur
  - `ic` for ImgChest
  - `ibb` for ImgBB
  - `kf` for KrakenFiles
- Added config keys for required API tokens.
- Updated help message for the new upload destinations.

## Notes

This follows the same direct upload integration pattern used for GoFile upload support.


https://github.com/anasty17/mirror-leech-telegram-bot/pull/1931/changes