### PR TITLE
Add URL Shortener Support

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -20,6 +20,7 @@ class Config:
     DATABASE_URL = ""
     DATABASE_NAME = "mltb"
     DEFAULT_UPLOAD = "rc"
+    URL_SHORTENER = "spoome"
     EQUAL_SPLITS = False
     EXCLUDED_EXTENSIONS = ""
     INCLUDED_EXTENSIONS = ""
@@ -159,6 +160,11 @@ class Config:
 
         if attr == "DEFAULT_UPLOAD" and converted_value not in {"gd", "bh", "gf"}:
             return "rc"
+
+        if attr == "URL_SHORTENER" and converted_value not in {
+            "spoome", "xgd", "cleanuri", "isgd"
+        }:
+            return "spoome"
 
         if attr in {
             "BASE_URL",

--- a/bot/core/handlers.py
+++ b/bot/core/handlers.py
@@ -279,6 +279,13 @@ def add_handlers():
         )
     )
     TgClient.bot.add_handler(
+        MessageHandler(
+            short_url,
+            filters=command(BotCommands.ShortCommand, case_sensitive=True)
+            & CustomFilters.authorized,
+        )
+    )
+    TgClient.bot.add_handler(
         CallbackQueryHandler(torrent_search_update, filters=regex("^torser"))
     )
     TgClient.bot.add_handler(

--- a/bot/helper/ext_utils/help_messages.py
+++ b/bot/helper/ext_utils/help_messages.py
@@ -506,6 +506,7 @@ NOTE: Try each command without any argument to see more detalis.
 /{BotCommands.CancelAllCommand} [query]: Cancel all [status] tasks.
 /{BotCommands.ListCommand} [query]: Search in Google Drive(s).
 /{BotCommands.SearchCommand} [query]: Search for torrents with API.
+/{BotCommands.ShortCommand} [url|host url]: Shorten a URL. Hosts: spoome, xgd, cleanuri, isgd.
 /{BotCommands.StatusCommand}: Shows a status of all the downloads.
 /{BotCommands.StatsCommand}: Show stats of the machine where the bot is hosted in.
 /{BotCommands.PingCommand}: Check how long it takes to Ping the Bot (Only Owner & Sudo).

--- a/bot/helper/ext_utils/url_shortener.py
+++ b/bot/helper/ext_utils/url_shortener.py
@@ -1,0 +1,86 @@
+from json import JSONDecodeError
+from urllib.parse import quote
+
+from httpx import AsyncClient, Timeout
+
+from ...core.config_manager import Config
+
+SHORTENER_HOSTS = {
+    "spoome": "spoo.me",
+    "xgd": "x.gd",
+    "cleanuri": "CleanURI",
+    "isgd": "is.gd",
+}
+
+_TIMEOUT = Timeout(connect=15.0, read=30.0, write=30.0, pool=15.0)
+
+
+def normalize_url(url):
+    url = url.strip()
+    if not url.startswith(("http://", "https://")):
+        url = f"https://{url}"
+    return url
+
+
+def _response_text(response):
+    return response.text[:500].strip()
+
+
+async def _json(response, host):
+    if response.status_code >= 400:
+        raise RuntimeError(
+            f"{host} failed [{response.status_code}]: {_response_text(response)}"
+        )
+    try:
+        return response.json()
+    except (JSONDecodeError, ValueError) as exc:
+        raise RuntimeError(
+            f"{host} returned non-JSON response: {_response_text(response)}"
+        ) from exc
+
+
+async def shorten_url(url, host=None):
+    host = (host or Config.URL_SHORTENER or "spoome").strip().lower()
+    if host not in SHORTENER_HOSTS:
+        raise RuntimeError(f"Unsupported shortener host: {host}")
+
+    url = normalize_url(url)
+
+    async with AsyncClient(timeout=_TIMEOUT, follow_redirects=False) as client:
+        if host == "spoome":
+            response = await client.post(
+                "https://spoo.me/",
+                data={"url": url},
+                headers={"Accept": "application/json"},
+            )
+            data = await _json(response, "spoo.me")
+            short_url = data.get("short_url") or data.get("shortUrl")
+
+        elif host == "xgd":
+            response = await client.get(f"https://x.gd/api.php?url={quote(url, safe='')}")
+            if response.status_code >= 400:
+                raise RuntimeError(
+                    f"x.gd failed [{response.status_code}]: {_response_text(response)}"
+                )
+            short_url = response.text.strip()
+
+        elif host == "cleanuri":
+            response = await client.post(
+                "https://cleanuri.com/api/v1/shorten",
+                data={"url": url},
+            )
+            data = await _json(response, "CleanURI")
+            short_url = data.get("result_url")
+
+        elif host == "isgd":
+            response = await client.get(
+                "https://is.gd/create.php",
+                params={"format": "json", "url": url},
+            )
+            data = await _json(response, "is.gd")
+            short_url = data.get("shorturl")
+
+    if not short_url:
+        raise RuntimeError(f"{SHORTENER_HOSTS[host]} response missing short URL")
+
+    return short_url, SHORTENER_HOSTS[host]

--- a/bot/helper/telegram_helper/bot_commands.py
+++ b/bot/helper/telegram_helper/bot_commands.py
@@ -25,6 +25,7 @@ class BotCommands:
     ListCommand = f"list{i}"
     SearchCommand = f"search{i}"
     StatusCommand = f"status{i}"
+    ShortCommand = f"short{i}"
     UsersCommand = f"users{i}"
     AuthorizeCommand = f"auth{i}"
     UnAuthorizeCommand = f"unauth{i}"

--- a/bot/modules/__init__.py
+++ b/bot/modules/__init__.py
@@ -34,6 +34,7 @@ from .status import task_status, status_pages
 from .users_settings import get_users_settings, edit_user_settings, send_user_settings
 from .ytdlp import ytdl, ytdl_leech
 from .gallery_dl import gallery_dl, gallery_dl_leech
+from .shortener import short_url
 
 __all__ = [
     "send_bot_settings",
@@ -91,4 +92,5 @@ __all__ = [
     "ytdl_leech",
     "gallery_dl",
     "gallery_dl_leech",
+    "short_url",
 ]

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -64,6 +64,7 @@ DEFAULT_VALUES = {
     "SEARCH_LIMIT": 0,
     "UPSTREAM_BRANCH": "master",
     "DEFAULT_UPLOAD": "rc",
+    "URL_SHORTENER": "spoome",
 }
 
 

--- a/bot/modules/shortener.py
+++ b/bot/modules/shortener.py
@@ -1,0 +1,72 @@
+from html import escape
+from re import search
+
+from ..core.config_manager import Config
+from ..helper.ext_utils.bot_utils import new_task
+from ..helper.ext_utils.url_shortener import SHORTENER_HOSTS, shorten_url
+from ..helper.telegram_helper.message_utils import send_message
+
+
+def _extract_url(text):
+    if not text:
+        return ""
+
+    match = search(r"https?://\S+", text)
+    if match:
+        return match.group(0)
+
+    return text.strip().split()[0] if text.strip() else ""
+
+
+def _get_short_args(message):
+    host = None
+    url = ""
+
+    parts = (message.text or "").split(maxsplit=1)
+    if len(parts) > 1:
+        args = parts[1].strip()
+        arg_parts = args.split(maxsplit=1)
+
+        if arg_parts and arg_parts[0].lower() in SHORTENER_HOSTS:
+            host = arg_parts[0].lower()
+            if len(arg_parts) > 1:
+                url = _extract_url(arg_parts[1])
+        else:
+            url = _extract_url(args)
+
+    if not url and message.reply_to_message:
+        reply = message.reply_to_message
+        url = _extract_url(reply.text or reply.caption or "")
+
+    return host, url
+
+
+@new_task
+async def short_url(_, message):
+    host, url = _get_short_args(message)
+
+    if not url:
+        hosts = "/".join(SHORTENER_HOSTS.keys())
+        await send_message(
+            message,
+            "<b>Send URL or reply to URL.</b>\n\n"
+            "<code>/short https://example.com</code>\n"
+            "<code>/short cleanuri https://example.com</code>\n\n"
+            f"Hosts: <code>{hosts}</code>",
+        )
+        return
+
+    try:
+        short, provider = await shorten_url(url, host)
+    except Exception as exc:
+        await send_message(
+            message,
+            f"<b>Shortener Error:</b> <code>{escape(str(exc))}</code>",
+        )
+        return
+
+    await send_message(
+        message,
+        f"🔗 <code>{escape(short)}</code>\n"
+        f"Provider: {escape(provider)}",
+    )


### PR DESCRIPTION
## Summary

Added URL shortener support with a new `/short` command.

Users can now shorten links directly from the bot by sending a URL with the command or by replying to a message that contains a URL.

## Features

- Added `/short` command
- Added reply-to-message URL shortening support
- Added configurable default shortener provider via `URL_SHORTENER`
- Supported providers:
  - spoo.me
  - x.gd
  - CleanURI
  - is.gd
- Added one-time provider override support, for example:
  - `/short cleanuri https://example.com`
  - `/short xgd https://example.com`

## Output Format

Shortened links are shown like this:

```txt
🔗 https://cleanuri.com/lm11rB
Provider: CleanURI